### PR TITLE
Handle undo with automapping.

### DIFF
--- a/Automap.cs
+++ b/Automap.cs
@@ -461,6 +461,13 @@ namespace Trizbort
             while (lineIndex < lines.Count)
             {
                 var line = lines[lineIndex].Trim();
+                if (line == "[Previous turn undone.]")
+                {
+                    // Ignore undo reports. This will have the effect of making this room
+                    // look like a non-verbose room.
+                    ++lineIndex;
+                    continue;
+                }
                 if (line.Length == 0)
                 {
                     // we hit a blank line; give up


### PR DESCRIPTION
When an UNDO is performed, the resulting room name is printed, followed
by "[Previous turn undone.]" I added simple code to ignore this line
when processing paragraphs, which makes this room look like one with a
non-verbose description. It's not perfect (for that, you'd have to store
a state graph), but it should handle most cases.