### PR TITLE
Eliminate pesky build warnings.

### DIFF
--- a/Canvas.cs
+++ b/Canvas.cs
@@ -741,7 +741,7 @@ namespace Trizbort
             element.Draw(graphics, palette, context);
           }
         }
-        catch (Exception e)
+        catch (Exception)
         {
           // avoid GDI+ exceptions (vast shapes, etc.) taking down the canvas
         }
@@ -1011,7 +1011,6 @@ namespace Trizbort
               roomTooltip.SetSuperTooltip(this, toolTip);
               
               Vector tPoint = new Vector();
-              Point xPoint = new Point();
               if (hoverElement is Room)
               {
                 var tRoom = (Room) hoverElement;

--- a/Element.cs
+++ b/Element.cs
@@ -266,9 +266,11 @@ namespace Trizbort
         public abstract eTooltipColor GetToolTipColor();
         public virtual Vector Position { get; set; }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
-            
+            //There is nothing to clean. 
+            if (Disposed != null)
+                Disposed(this, EventArgs.Empty);
         }
 
         public ISite Site

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -403,7 +403,7 @@ namespace Trizbort
       {
         savePDF(pdfFile);
       }
-      catch (Exception ex)
+      catch (Exception)
       {
         return string.Empty;
       }

--- a/Project.cs
+++ b/Project.cs
@@ -270,7 +270,7 @@ namespace Trizbort
       private void setVersion(string versionNumber)
       {
         try { Version = Version.Parse(versionNumber); }
-        catch (Exception e)
+        catch (Exception)
         {
           Version = new Version(0,0,0,0);
         }

--- a/Room.cs
+++ b/Room.cs
@@ -877,10 +877,6 @@ namespace Trizbort
         scribe.Attribute("isDark", IsDark);
       }
       scribe.Attribute("description", PrimaryDescription);
-      // Added for room specific fill color, down to the next comment
-      var rValue = "";
-      var bValue = "";
-      var gValue = "";
 
       var colorValue = Colors.SaveColor(RoomFill);
       scribe.Attribute("roomFill", colorValue);

--- a/RoomExtensions.cs
+++ b/RoomExtensions.cs
@@ -11,23 +11,17 @@ namespace Trizbort
       {
         case BorderDashStyle.Solid:
           return DashStyle.Solid;
-          break;
         case BorderDashStyle.Dot:
           return DashStyle.Dot;
-          break;
         case BorderDashStyle.Dash:
           return DashStyle.Dash;
-          break;
         case BorderDashStyle.DashDot:
           return DashStyle.DashDot;
-          break;
         case BorderDashStyle.DashDotDot:
           return DashStyle.DashDotDot;
-          break;
         case BorderDashStyle.Custom:
         case BorderDashStyle.None:
           return DashStyle.Custom;
-        break;
         default:
           throw new ArgumentOutOfRangeException("cxx", cxx, null);
       }

--- a/Trizbort.csproj
+++ b/Trizbort.csproj
@@ -268,9 +268,6 @@
   <ItemGroup>
     <Content Include="Images\Arrow.png" />
     <Content Include="Images\Blank.png" />
-    <Content Include="Images\door.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="Images\DrawLine.cur" />
     <Content Include="Images\DrawLine.png" />
     <Content Include="Images\DrawLineInverted.cur" />


### PR DESCRIPTION
Probably those catch(Exception) statements should be made more specific, but for now this should eliminate the 14 build warnings we see.