### PR TITLE
Tweak the ZIL exporter

### DIFF
--- a/Export/ZilExporter.cs
+++ b/Export/ZilExporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing.Text;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Trizbort.Extensions;
 using static System.String;
 
@@ -12,6 +13,7 @@ namespace Trizbort.Export
   {
     const char SINGLE_QUOTE = '\'';
     const char DOUBLE_QUOTE = '"';
+    const char SPACE = ' ';
 
     public override List<KeyValuePair<string, string>> FileDialogFilters => new List<KeyValuePair<string, string>>
     {
@@ -36,48 +38,74 @@ namespace Trizbort.Export
       writer.WriteLine($"{DOUBLE_QUOTE}Main Loop{DOUBLE_QUOTE}");
       writer.WriteLine();
       writer.WriteLine($"<CONSTANT GAME-BANNER {DOUBLE_QUOTE}{title}|An interactive fiction by {author}{DOUBLE_QUOTE}>");
-      writer.WriteLine($"<ROUTINE GO()");
+      writer.WriteLine();
+      writer.WriteLine($"<ROUTINE GO ()");
       writer.WriteLine($"    <CRLF> <CRLF>");
-      writer.WriteLine($"    <TELL {DOUBLE_QUOTE}{description}{DOUBLE_QUOTE} CR CR>");
+      writer.WriteLine($"    <TELL {toZILString(description)} CR CR>");
       writer.WriteLine($"    <V-VERSION> <CRLF>");
       writer.WriteLine($"    <SETG HERE ,{startingRoom.ExportName}>");
       writer.WriteLine($"    <MOVE ,PLAYER ,HERE>");
       writer.WriteLine($"    <V-LOOK>");
-      writer.WriteLine($"    <REPEAT()");
+      writer.WriteLine($"    <REPEAT ()");
       writer.WriteLine($"        <COND (<PARSER>");
-      writer.WriteLine($"               <PERFORM, PRSA, PRSO, PRSI>");
-      writer.WriteLine($"               <APPLY <GETP, HERE, P?ACTION> ,M-END>");
-      writer.WriteLine($"               <OR <GAME-VERB?> <CLOCKER>>)>");
+      writer.WriteLine($"               <PERFORM ,PRSA ,PRSO ,PRSI>");
+      writer.WriteLine($"               <COND (<NOT <GAME-VERB?>>");
+      writer.WriteLine($"                      <APPLY <GETP ,HERE ,P?ACTION> ,M-END>");
+      writer.WriteLine($"                      <CLOCKER>)>)>");
       writer.WriteLine($"        <SETG HERE <LOC ,WINNER>>>>");
       writer.WriteLine();
       writer.WriteLine($"<INSERT-FILE {DOUBLE_QUOTE}parser{DOUBLE_QUOTE}>");
       writer.WriteLine();
+      
+      if (!string.IsNullOrWhiteSpace(history))
+      {
+        exportHistory(writer, history);
+      }
+
       writer.WriteLine($"{DOUBLE_QUOTE}Objects{DOUBLE_QUOTE}");
     }
-
+    
+    private void exportHistory(TextWriter writer, string history)
+    {
+      writer.WriteLine("<SYNTAX ABOUT = V-ABOUT>");
+      writer.WriteLine();
+      writer.WriteLine("<ROUTINE V-ABOUT ()");
+      writer.WriteLine($"    <TELL {toZILString(history)} CR>>");
+      writer.WriteLine();
+    }
+    
     protected override void ExportContent(TextWriter writer)
     {
       // export location
+      bool needConditionalFunction = false, wroteConditionalFunction = false;
       foreach (var location in LocationsInExportOrder)
       {
         location.Exported = true;
 
         writer.WriteLine();
         writer.WriteLine($"<ROOM {location.ExportName}");
-        writer.WriteLine($"    (DESC {DOUBLE_QUOTE}{location.Room.Name}{DOUBLE_QUOTE})");
-        writer.WriteLine($"    (IN ROOMS)");
-        writer.WriteLine($"    (LDESC {DOUBLE_QUOTE}{location.Room.PrimaryDescription}{DOUBLE_QUOTE})");
+        writer.WriteLine($"    (DESC {toZILString(location.Room.Name)})");
+        writer.Write($"    (IN ROOMS)");
+
+        if (!string.IsNullOrWhiteSpace(location.Room.PrimaryDescription))
+        {
+          writer.WriteLine();
+          writer.Write($"    (LDESC {toZILString(location.Room.PrimaryDescription)})");
+        }
 
         foreach (var direction in AllDirections)
         {
           var exit = location.GetBestExit(direction);
           if (exit != null && exit.Conditional)
           {
-            writer.WriteLine($"    ({toZILPropertyName(direction)} SORRY {DOUBLE_QUOTE}An export nymph appears on your keyboard. She says, 'You can't go that way, as that exit was marked as conditional, you know, a dotted line, in Trizbort. Obviously in your game you'll have a better rationale for this than, er, me.' She looks embarrassed. 'Bye!'{DOUBLE_QUOTE})");
+            writer.WriteLine();
+            writer.Write($"    ({toZILPropertyName(direction)} PER TRIZBORT-CONDITIONAL-EXIT)");
+            needConditionalFunction = true;
           }
           else if (exit != null)
           {
-            writer.WriteLine($"    ({toZILPropertyName(direction)} TO {exit.Target.ExportName})");
+            writer.WriteLine();
+            writer.Write($"    ({toZILPropertyName(direction)} TO {exit.Target.ExportName})");
             var oppositeDirection = CompassPointHelper.GetOpposite(direction);
             if (Exit.IsReciprocated(location, direction, exit.Target))
             {
@@ -87,13 +115,24 @@ namespace Trizbort.Export
           }
         }
 
-
         if (!location.Room.IsDark)
         {
-          writer.WriteLine("    (FLAGS LIGHTBIT)");
+          writer.WriteLine();
+          writer.Write("    (FLAGS LIGHTBIT)");
         }
         writer.WriteLine(">");
         writer.WriteLine();
+
+        if (needConditionalFunction && !wroteConditionalFunction)
+        {
+          writer.WriteLine();
+          writer.WriteLine("<ROUTINE TRIZBORT-CONDITIONAL-EXIT ()");
+          writer.WriteLine($"    <TELL {DOUBLE_QUOTE}An export nymph appears on your keyboard. She says, 'You can't go that way, as that exit was marked as conditional, you know, a dotted line, in Trizbort. Obviously in your game you'll have a better rationale for this than, er, me.' She looks embarrassed. 'Bye!'{DOUBLE_QUOTE} CR>");
+          writer.WriteLine("    <RFALSE>>");
+          writer.WriteLine();
+          wroteConditionalFunction = true;
+        }
+
         exportThings(writer, location.Things, null, 1);
       }
     }
@@ -131,6 +170,15 @@ namespace Trizbort.Export
       }
     }
 
+    private static string toZILString(string str)
+    {
+      if (str == null)
+      {
+        str = string.Empty;
+      }
+      return DOUBLE_QUOTE + str.Replace('\n', '|').Replace($"{DOUBLE_QUOTE}", $"\\{DOUBLE_QUOTE}") + DOUBLE_QUOTE;
+    }
+
     private static void exportThings(TextWriter writer, List<Thing> things, Thing container, int indent)
     {
       foreach (var thing in things.Where(p=>p.Container == container))
@@ -139,14 +187,21 @@ namespace Trizbort.Export
         writer.WriteLine($"<OBJECT {thing.ExportName}");
 
         if (thing.Container == null)
-          writer.WriteLine($"    (LOC {thing.Location.ExportName})");
+          writer.WriteLine($"    (IN {thing.Location.ExportName})");
         else
-          writer.WriteLine($"    (LOC {thing.Container.ExportName})");
+          writer.WriteLine($"    (IN {thing.Container.ExportName})");
 
-        writer.WriteLine($"    (DESC {DOUBLE_QUOTE}{thing.DisplayName}{DOUBLE_QUOTE})");
-        writer.WriteLine($"    (SYNONYM {getSynonyms(thing)})");
-        writer.WriteLine($"    (FLAGS {getFlags(thing)})");
-        writer.WriteLine(">");
+        writer.WriteLine($"    (DESC {toZILString(thing.DisplayName)})");
+
+        var words = getObjectWords(thing);
+        if (words.Count > 0) {
+          writer.WriteLine($"    (SYNONYM {words[words.Count - 1]})");
+        }
+        if (words.Count > 1) {
+          writer.WriteLine($"    (ADJECTIVE {Join($"{SPACE}", words.Take(words.Count - 1))})");
+        }
+
+        writer.WriteLine($"    (FLAGS {getFlags(thing)})>");
         writer.WriteLine();
 
         if (thing.Contents.Any())
@@ -154,36 +209,33 @@ namespace Trizbort.Export
       }
     }
 
-    private static string getSynonyms(Thing thing)
+    private static IList<string> getObjectWords(Thing thing)
     {
       string synonyms = Empty;
       var list = new List<string>();
 
       var words = thing.DisplayName.Split(' ').ToList();
 
-      words.ForEach(p=>list.Add(stripOddCharacters(p)));
+      words.ForEach(p=>list.Add(stripOddCharacters(p).ToUpper()));
 
-      synonyms += Join(" ", list).ToUpper();
-      return synonyms;
+      return list;
     }
 
     private static string getFlags(Thing thing)
     {
-      string flags = Empty;
+      var flags = new StringBuilder("TAKEBIT");
 
       if (thing.DisplayName.StartsWithVowel())
       {
-        flags += "VOWELBIT ";
+        flags.Append(" VOWELBIT");
       }
 
       if (thing.Contents.Any())
       {
-        flags += "CONTBIT ";
+        flags.Append(" CONTBIT");
       }
 
-
-      flags += "TAKEBIT ";
-      return flags;
+      return flags.ToString();
     }
 
 


### PR DESCRIPTION
- Update main loop so M-END doesn't run for meta verbs.
- Escape contents of strings.
- Export history (creating an ABOUT verb).
- Don't write empty room descriptions.
- Use a PER routine for conditional exits.
- Set object SYNONYM and ADJECTIVE separately.
- Fix spacing/style nits.