### PR TITLE
#89 and a tweak to the flicker

### DIFF
--- a/Canvas.Designer.cs
+++ b/Canvas.Designer.cs
@@ -67,6 +67,7 @@ namespace Trizbort
       this.handDrawnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.ellipseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.roundedEdgesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.octagonalEdgesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.joinRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.swapObjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.objectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -288,7 +289,9 @@ namespace Trizbort
       this.roomShapeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.handDrawnToolStripMenuItem,
             this.ellipseToolStripMenuItem,
-            this.roundedEdgesToolStripMenuItem});
+            this.roundedEdgesToolStripMenuItem,
+            this.octagonalEdgesToolStripMenuItem
+      });
       this.roomShapeToolStripMenuItem.Name = "roomShapeToolStripMenuItem";
       this.roomShapeToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
       this.roomShapeToolStripMenuItem.Text = "Room Shape";
@@ -317,6 +320,14 @@ namespace Trizbort
       this.roundedEdgesToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
       this.roundedEdgesToolStripMenuItem.Text = "Rounded Edges";
       this.roundedEdgesToolStripMenuItem.Click += new System.EventHandler(this.roundedEdgesToolStripMenuItem_Click);
+      // 
+      // octagonalEdgesToolStripMenuItem
+      // 
+      this.octagonalEdgesToolStripMenuItem.Name = "octagonalEdgesToolStripMenuItem";
+      this.octagonalEdgesToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+8";
+      this.octagonalEdgesToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
+      this.octagonalEdgesToolStripMenuItem.Text = "Octagonal Edges";
+      this.octagonalEdgesToolStripMenuItem.Click += new System.EventHandler(this.octagonalEdgesToolStripMenuItem_Click);
       // 
       // joinRoomsToolStripMenuItem
       // 
@@ -482,6 +493,7 @@ namespace Trizbort
     private System.Windows.Forms.ToolStripMenuItem handDrawnToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem ellipseToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem roundedEdgesToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem octagonalEdgesToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem addRoomToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
     private System.Windows.Forms.ToolStripMenuItem m_lineStylesMenuItem;

--- a/Canvas.cs
+++ b/Canvas.cs
@@ -3294,6 +3294,15 @@ namespace Trizbort
       Invalidate();
     }
 
+    private void octagonalEdgesToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+      foreach (var room in SelectedRooms)
+      {
+        room.Shape = RoomShape.Octagonal;
+      }
+      Invalidate();
+    }
+
     private void objectsToolStripMenuItem_Click(object sender, EventArgs e)
     {
       SwapRooms();

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -117,6 +117,7 @@ namespace Trizbort
       this.handDrawnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.ellipseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.roundedEdgesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.octagonalEdgesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
       this.joinRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
@@ -685,7 +686,8 @@ namespace Trizbort
       this.roomShapeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.handDrawnToolStripMenuItem,
             this.ellipseToolStripMenuItem,
-            this.roundedEdgesToolStripMenuItem});
+            this.roundedEdgesToolStripMenuItem,
+            this.octagonalEdgesToolStripMenuItem});
       this.roomShapeToolStripMenuItem.Name = "roomShapeToolStripMenuItem";
       this.roomShapeToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
       this.roomShapeToolStripMenuItem.Text = "Room &Shape";
@@ -713,6 +715,14 @@ namespace Trizbort
       this.roundedEdgesToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
       this.roundedEdgesToolStripMenuItem.Text = "Rounded Edges";
       this.roundedEdgesToolStripMenuItem.Click += new System.EventHandler(this.roundedEdgesToolStripMenuItem_Click);
+      // 
+      // octagonalEdgesToolStripMenuItem
+      // 
+      this.octagonalEdgesToolStripMenuItem.Name = "octagonalEdgesToolStripMenuItem";
+      this.octagonalEdgesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
+      this.octagonalEdgesToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
+      this.octagonalEdgesToolStripMenuItem.Text = "Octagonal Edges";
+      this.octagonalEdgesToolStripMenuItem.Click += new System.EventHandler(this.octagonalEdgesToolStripMenuItem_Click);
       // 
       // toolStripSeparator18
       // 
@@ -1343,6 +1353,7 @@ namespace Trizbort
     private System.Windows.Forms.ToolStripMenuItem handDrawnToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem ellipseToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem roundedEdgesToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem octagonalEdgesToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator18;
     private System.Windows.Forms.ToolStripMenuItem joinRoomsToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator19;

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -820,6 +820,9 @@ namespace Trizbort
       m_editCopyMenuItem.Enabled = Canvas.SelectedElement != null;
       m_editCopyColorToolMenuItem.Enabled = Canvas.HasSingleSelectedElement && (Canvas.SelectedElement is Room);
       m_editPasteMenuItem.Enabled = (!string.IsNullOrEmpty(Clipboard.GetText()) && ((Clipboard.GetText().Replace("\r\n", "|").Split('|')[0] == "Elements") || (Clipboard.GetText().Replace("\r\n", "|").Split('|')[0] == "Colors")));
+      if (Canvas.HasSingleSelectedElement) //Allow flipping light in all rooms if 1+ are selected. Issue #138 flicker
+        m_editIsDarkMenuItem.Enabled = Canvas.HasSingleSelectedElement && (Canvas.SelectedElement is Room);
+      else
         m_editIsDarkMenuItem.Enabled = hasSelectedElement;
       m_editIsDarkMenuItem.Checked = Canvas.HasSingleSelectedElement && (Canvas.SelectedElement is Room) && ((Room)Canvas.SelectedElement).IsDark;
       m_editRenameMenuItem.Enabled = Canvas.HasSingleSelectedElement && (Canvas.SelectedElement is Room);
@@ -833,6 +836,7 @@ namespace Trizbort
       handDrawnToolStripMenuItem.Enabled = (Canvas.SelectedRooms.Any());
       ellipseToolStripMenuItem.Enabled = (Canvas.SelectedRooms.Any());
       roundedEdgesToolStripMenuItem.Enabled = (Canvas.SelectedRooms.Any());
+      octagonalEdgesToolStripMenuItem.Enabled = (Canvas.SelectedRooms.Any());
       m_reverseLineMenuItem.Enabled = Canvas.HasSelectedElement<Connection>();
 
       // automapping
@@ -1164,6 +1168,15 @@ namespace Trizbort
       foreach (var room in Canvas.SelectedRooms)
       {
         room.Shape = RoomShape.RoundedCorners;
+      }
+      Invalidate();
+    }
+
+    private void octagonalEdgesToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+      foreach (var room in Canvas.SelectedRooms)
+      {
+        room.Shape = RoomShape.Octagonal;
       }
       Invalidate();
     }

--- a/RoomPropertiesDialog.Designer.cs
+++ b/RoomPropertiesDialog.Designer.cs
@@ -83,6 +83,7 @@ namespace Trizbort
       this.itemStraightEdges = new DevComponents.Editors.ComboItem();
       this.itemRoundedCorners = new DevComponents.Editors.ComboItem();
       this.itemEllipse = new DevComponents.Editors.ComboItem();
+      this.itemOctagonal = new DevComponents.Editors.ComboItem();
       this.pnlSampleRoomShape = new System.Windows.Forms.Panel();
       this.superTabItem1 = new DevComponents.DotNetBar.SuperTabItem();
       this.superTabControlPanel1 = new DevComponents.DotNetBar.SuperTabControlPanel();
@@ -555,6 +556,10 @@ namespace Trizbort
       // itemEllipse
       // 
       this.itemEllipse.Text = "Ellipse";
+      // 
+      // itemEllipse
+      // 
+      this.itemOctagonal.Text = "Octagonal";
       // 
       // pnlSampleRoomShape
       // 
@@ -1096,6 +1101,7 @@ namespace Trizbort
     private DevComponents.Editors.ComboItem itemStraightEdges;
     private DevComponents.Editors.ComboItem itemRoundedCorners;
     private DevComponents.Editors.ComboItem itemEllipse;
+    private DevComponents.Editors.ComboItem itemOctagonal;
     private DevComponents.DotNetBar.Controls.GroupPanel groupRoundedCorners;
     private System.Windows.Forms.CheckBox chkCornersSame;
     private System.Windows.Forms.CheckBox chkStartRoom;

--- a/RoomPropertiesDialog.cs
+++ b/RoomPropertiesDialog.cs
@@ -89,6 +89,7 @@ namespace Trizbort
     public bool RoundedCorners { get { return cboDrawType.SelectedItem == itemRoundedCorners; } set { if (value) cboDrawType.SelectedItem = itemRoundedCorners; } }
     public bool Ellipse { get { return cboDrawType.SelectedItem == itemEllipse; } set { if (value) cboDrawType.SelectedItem = itemEllipse; } }
     public bool StraightEdges { get { return cboDrawType.SelectedItem == itemStraightEdges; } set { if (value) cboDrawType.SelectedItem = itemStraightEdges; } }
+    public bool Octagonal { get { return cboDrawType.SelectedItem == itemOctagonal; } set { if (value) cboDrawType.SelectedItem = itemOctagonal; } }
 
     public CornerRadii Corners
     {


### PR DESCRIPTION
I noticed I took code out to test a few things with the flicker for the previous merge, to make sure things worked a certain way, but I forgot to put the line back in. #145 is the issue.

I have added octagonal shapes. I cut the vertical/horizontal sides to half the actual length, but this can be changed in the quarterPoint function. Which might need to be renamed. (WeightPoint?) I made sure that first-room highlighting and select highlighting works, and both the context and pull-down menus should show the option.
