### PR TITLE
Mark project dirty if colors in Color tab changed

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -671,6 +671,7 @@ namespace Trizbort
         {
           for (var index = 0; index < Colors.Count; ++index)
           {
+            if (Color[index] != dialog.Color[index]) { Project.Current.IsDirty = true; }
             Color[index] = dialog.Color[index];
           }
 


### PR DESCRIPTION
I found this when I opened a project, changed the start room color, and closed it. Trizbort doesn't see color changes as changes in the pronect.

Given that this code is so close to other lines marking the project as dirty, I am vaguely worried Genstein had a reason not to mark some changes as worth saving. But I think I've had trizbort "forget" other color change saves when that's all I do & from a user perspective, I think this should be there.