### PR TITLE
#221 Inform 7 export now by-region/room

### DIFF
--- a/AppSettingsDialog.Designer.cs
+++ b/AppSettingsDialog.Designer.cs
@@ -32,7 +32,7 @@
       this.chkLoadLast = new System.Windows.Forms.CheckBox();
       this.m_invertWheelCheckBox = new System.Windows.Forms.CheckBox();
       this.labelG = new System.Windows.Forms.Label();
-      this.cboAdjustGranularity = new System.Windows.Forms.ComboBox();
+      this.cboPortAdjustDetail = new System.Windows.Forms.ComboBox();
       this.cboImageSaveType = new System.Windows.Forms.ComboBox();
       this.label2 = new System.Windows.Forms.Label();
       this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
@@ -86,7 +86,7 @@
       this.groupBox1.Controls.Add(this.chkSaveAtZoom);
       this.groupBox1.Controls.Add(this.m_invertWheelCheckBox);
       this.groupBox1.Controls.Add(this.chkLoadLast);
-      this.groupBox1.Controls.Add(this.cboAdjustGranularity);
+      this.groupBox1.Controls.Add(this.cboPortAdjustDetail);
       this.groupBox1.Controls.Add(this.labelG);
       this.groupBox1.Location = new System.Drawing.Point(6, 16);
       this.groupBox1.Name = "groupBox1";
@@ -127,19 +127,19 @@
       this.m_invertWheelCheckBox.Text = "Invert Mouse Wheel &Zoom";
       this.m_invertWheelCheckBox.UseVisualStyleBackColor = true;
       // 
-      // cboAdjustGranularity
+      // cboPortAdjustDetail
       // 
-      this.cboAdjustGranularity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.cboAdjustGranularity.FormattingEnabled = true;
-      this.cboAdjustGranularity.Items.AddRange(new object[] {
-            "Fourths ",
-            "Eighths ",
-            "Sixteenths "});
-      this.cboAdjustGranularity.Location = new System.Drawing.Point(300, 40);
-      this.cboAdjustGranularity.Name = "cboAdjustGranularity";
-      this.cboAdjustGranularity.Size = new System.Drawing.Size(84, 17);
-      this.cboAdjustGranularity.TabIndex = 3;
-      this.cboAdjustGranularity.Enter += new System.EventHandler(this.cboAdjustGranularity_Enter);
+      this.cboPortAdjustDetail.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cboPortAdjustDetail.FormattingEnabled = true;
+      this.cboPortAdjustDetail.Items.AddRange(new object[] {
+            "NSEW (4)",
+            "Diagonals (8)",
+            "All ports (16)"});
+      this.cboPortAdjustDetail.Location = new System.Drawing.Point(300, 40);
+      this.cboPortAdjustDetail.Name = "cboPortAdjustDetail";
+      this.cboPortAdjustDetail.Size = new System.Drawing.Size(84, 17);
+      this.cboPortAdjustDetail.TabIndex = 3;
+      this.cboPortAdjustDetail.Enter += new System.EventHandler(this.cboPortAdjustDetail_Enter);
       // 
       // labelG
       // 
@@ -148,7 +148,7 @@
       this.labelG.Name = "labelG";
       this.labelG.Size = new System.Drawing.Size(130,21);
       this.labelG.TabIndex = 2;
-      this.labelG.Text = "Adjust &Granularity:";
+      this.labelG.Text = "Port Ad&just Detail:";
       // 
       // cboImageSaveType
       // 
@@ -423,7 +423,7 @@
 		private System.Windows.Forms.Button m_cancelButton;
 		private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox m_invertWheelCheckBox;
-        private System.Windows.Forms.ComboBox cboAdjustGranularity;
+        private System.Windows.Forms.ComboBox cboPortAdjustDetail;
         private System.Windows.Forms.Label labelG;
         private System.Windows.Forms.ComboBox cboImageSaveType;
         private System.Windows.Forms.Label label2;

--- a/AppSettingsDialog.cs
+++ b/AppSettingsDialog.cs
@@ -70,10 +70,10 @@ namespace Trizbort
       set { cboImageSaveType.SelectedIndex = value; }
     }
 
-    public int AdjustGranularity
+    public int PortAdjustDetail
     {
-      get { return cboAdjustGranularity.SelectedIndex; }
-      set { cboAdjustGranularity.SelectedIndex = value; }
+      get { return cboPortAdjustDetail.SelectedIndex; }
+      set { cboPortAdjustDetail.SelectedIndex = value; }
     }
 
     private void AppSettingsDialog_Load(object sender, System.EventArgs e)
@@ -81,9 +81,9 @@ namespace Trizbort
       
     }
 
-    private void cboAdjustGranularity_Enter(object sender, System.EventArgs e)
+    private void cboPortAdjustDetail_Enter(object sender, System.EventArgs e)
     {
-      cboAdjustGranularity.DroppedDown = true;
+      cboPortAdjustDetail.DroppedDown = true;
     }
 
     private void cboImageSaveType_Enter(object sender, System.EventArgs e)

--- a/Canvas.cs
+++ b/Canvas.cs
@@ -1206,10 +1206,14 @@ namespace Trizbort
           }
           else if ((ModifierKeys & Keys.Control) == Keys.Control)
           {
-            Settings.AdjustGranularity++; Settings.AdjustGranularity %= 3;
-            int x = 4 << Settings.AdjustGranularity; // yeah this is cutesy code but it does the job
-            if ((ModifierKeys & Keys.Shift) == Keys.Shift) //Shift pops up current granularity
-              MessageBox.Show("Adjust Granularity " +( (Settings.AdjustGranularity == 0) ? "de" : "in") + "creased to " + x.ToString() + ".", "Granularity Adjust");
+            var desc = new string[3];
+            desc[0] = "NSEW";
+            desc[1] = "diagonals";
+            desc[2] = "all ports";
+            Settings.PortAdjustDetail++; Settings.PortAdjustDetail %= 3;
+            int x = 4 << Settings.PortAdjustDetail; // yeah this is cutesy code but it does the job
+            if ((ModifierKeys & Keys.Shift) == Keys.Shift) //Shift pops up current port adjust detail
+              MessageBox.Show("Available ports for readjustment " +( (Settings.PortAdjustDetail == 0) ? "de" : "in") + "creased to " + x.ToString() + " (" + desc[Settings.PortAdjustDetail] +").", "Port Detail Adjust");
           }
           break;
         case Keys.I:

--- a/Export/Inform7Exporter.cs
+++ b/Export/Inform7Exporter.cs
@@ -111,8 +111,10 @@ namespace Trizbort.Export
 
         if (!string.IsNullOrEmpty(location.Room.Region) && !location.Room.Region.Equals(Region.DefaultRegion))
           writer.WriteLine(" It is in {0}.", RegionsInExportOrder.Find(p=>p.Region.RegionName == location.Room.Region).ExportName);
+        else
+          writer.WriteLine();
 
-        writer.WriteLine(); // blank line
+        writer.WriteLine(); // extra blank line for formatting and so utterly blank rooms don't throw an error in Inform IDE
 
         if (location.Room.IsStartRoom)
         {

--- a/Export/Inform7Exporter.cs
+++ b/Export/Inform7Exporter.cs
@@ -65,34 +65,32 @@ namespace Trizbort.Export
         writer.WriteLine();
       }
 
+      writer.WriteLine("Volume Trizbort generated map");
+      writer.WriteLine();
+
       if (!string.IsNullOrWhiteSpace(history))
         exportHistory(writer, history);
     }
 
     private static void exportHistory(TextWriter writer, string history)
     {
+      string historyCoded = history.Replace("\r\n", "\r\n[line break]");
       writer.WriteLine("chapter about");
       writer.WriteLine("");
       writer.WriteLine("abouting is an action out of world.");
       writer.WriteLine("understand the command \"about\" as something new.");
       writer.WriteLine("understand \"about\" as abouting.");
-      writer.WriteLine($"carry out abouting: say \"{history}\".");
+      writer.WriteLine($"carry out abouting: say \"{historyCoded}\".");
+      writer.WriteLine("");
     }
 
-    protected override void ExportContent(TextWriter writer)
+    private bool printThisLoc(TextWriter writer, Location location)
     {
-      // export regions
-      foreach (var region in RegionsInExportOrder)
-      {
-        writer.WriteLine("There is a region called {0}.", getExportName(region.ExportName, null));
-        writer.WriteLine();
-      }
-
-      // export each location
-      foreach (var location in LocationsInExportOrder)
-      {
         // remember we've exported this location
         location.Exported = true;
+
+        writer.WriteLine("part {0}", location.ExportName);
+        writer.WriteLine();
 
         // tiresome format, avoids I7 errors:
         // these can occur with rooms called "West of House", or one room called "Cave" and one called "Damp Cave", etc.
@@ -112,9 +110,8 @@ namespace Trizbort.Export
         }
 
         if (!string.IsNullOrEmpty(location.Room.Region) && !location.Room.Region.Equals(Region.DefaultRegion))
-          writer.Write(" It is in {0}.",  RegionsInExportOrder.Find(p=>p.Region.RegionName == location.Room.Region).ExportName);
+          writer.WriteLine(" It is in {0}.", RegionsInExportOrder.Find(p=>p.Region.RegionName == location.Room.Region).ExportName);
 
-        writer.WriteLine(); // end the previous line
         writer.WriteLine(); // blank line
 
         if (location.Room.IsStartRoom)
@@ -122,19 +119,44 @@ namespace Trizbort.Export
           writer.Write("The player is in {0}.", location.ExportName);
           writer.WriteLine();
         }
-      }
 
-      // export the chosen exits from each location.
-      foreach (var location in LocationsInExportOrder)
-      {
+        var exportedThings = false;
+
+        foreach (var thing in location.Things)
+        {
+          exportedThings = true;
+          if (thing.Container == null)
+          {
+             writer.Write("{0}{1} {2} in {3}.", getArticle(thing.ExportName), thing.ExportName, isAre(thing.ExportName), thing.Location.ExportName);
+          }
+          else
+          {
+              writer.Write("{0}{1} {2} in the {3}.", getArticle(thing.ExportName), thing.ExportName, isAre(thing.ExportName), thing.Container.ExportName);
+          }
+          if (thing.DisplayName != thing.ExportName)
+          {
+              writer.Write(" It is privately-named. The printed name of it is {0}{1} Understand {2} as {3}.", toInform7PrintableString(thing.DisplayName), thing.DisplayName.EndsWith(".") ? string.Empty : ".", toInform7UnderstandWords(thing.DisplayName), thing.ExportName);
+          }
+          writer.WriteLine();
+        }
+
+        if (exportedThings)
+        {
+          // add a blank line if we need one
+          writer.WriteLine();
+        }
+
+        var exportedExits = false;
         // export the chosen exits from this location.
         foreach (var direction in AllDirections)
         {
           var exit = location.GetBestExit(direction);
-          if (exit != null && !exit.Exported)
+
+          if ((exit != null) && (exit.Exported == false))
           {
             // remember we've exported this exit
             exit.Exported = true;
+            exportedExits = true;
 
             writer.Write("{0} of {1} is {2}.", getInform7Name(direction), location.ExportName, exit.Target.ExportName);
             var oppositeDirection = CompassPointHelper.GetOpposite(direction);
@@ -147,72 +169,70 @@ namespace Trizbort.Export
             }
             else if (exit.Target.GetBestExit(oppositeDirection) == null)
             {
-              // if we aren't laying down a contridiction which I7 will pick up,
+              // if we aren't laying down a contradiction which I7 will pick up,
               // then be clear about one way connections.
               writer.Write(" {0} of {1} is nowhere.", getInform7Name(oppositeDirection), exit.Target.ExportName);
             }
             writer.WriteLine();
           }
         }
-      }
+        if (exportedExits) writer.WriteLine();
 
-      writer.WriteLine();
-
-      // if an exit is conditional, block it.
-      var wroteConditionalFunction = false;
-      foreach (var location in LocationsInExportOrder)
-      {
+        var wroteConditionalExit = false;
         foreach (var direction in AllDirections)
         {
           var exit = location.GetBestExit(direction);
           if (exit != null && exit.Conditional)
           {
-            if (!wroteConditionalFunction)
-            {
-              writer.WriteLine("To block conditional exits:");
-              writer.WriteLine("\tsay \"An export nymph appears on your keyboard. She says, 'You can't go that way, as that exit was marked as conditional, you know, a dotted line, in Trizbort. Obviously in your game you'll have a better rationale for this than, er, me.' She looks embarrassed. 'Bye!'\"");
-              writer.WriteLine();
-              wroteConditionalFunction = true;
-            }
-
+            wroteConditionalExit = true;
             writer.WriteLine("Instead of going {0} from {1}, block conditional exits.", getInform7Name(direction).ToLowerInvariant(), location.ExportName);
           }
         }
-      }
+        if (wroteConditionalExit)
+          writer.WriteLine();
+        return wroteConditionalExit;
 
-      if (wroteConditionalFunction)
+    }
+
+    protected override void ExportContent(TextWriter writer)
+    {
+      bool anyConditionalExits = false;
+
+      if (MapStatistics.NumberOfRoomsWithoutRegion() > 0)
       {
-        // add a blank line if we need one
-        writer.WriteLine();
-      }
+      writer.WriteLine("book Regionless Rooms");
+      writer.WriteLine();
 
-      var exportedThings = false;
       foreach (var location in LocationsInExportOrder)
       {
-        foreach (var thing in location.Things)
-        {
-          exportedThings = true;
-          if (thing.Container == null)
-          {
-            writer.Write("{0}{1} {2} in {3}.", getArticle(thing.ExportName), thing.ExportName, isAre(thing.ExportName), thing.Location.ExportName);
-          }
-          else
-          {
-            writer.Write("{0}{1} {2} in the {3}.", getArticle(thing.ExportName), thing.ExportName, isAre(thing.ExportName), thing.Container.ExportName);
-          }
-          if (thing.DisplayName != thing.ExportName)
-          {
-            writer.Write(" It is privately-named. The printed name of it is {0}{1} Understand {2} as {3}.", toInform7PrintableString(thing.DisplayName), thing.DisplayName.EndsWith(".") ? string.Empty : ".", toInform7UnderstandWords(thing.DisplayName), thing.ExportName);
-          }
-          writer.WriteLine();
-        }
+        if (location.Room.Region != "NoRegion") { continue; }
+        anyConditionalExits |= printThisLoc(writer, location);
+      }
+      }
+      // export regions
+      foreach (var region in RegionsInExportOrder)
+      {
+        writer.WriteLine("book {0}", getExportName(region.ExportName, null));
+        writer.WriteLine();
+        writer.WriteLine("There is a region called {0}.", getExportName(region.ExportName, null));
+        writer.WriteLine();
+      // export each location
+      foreach (var location in LocationsInExportOrder)
+      {
+        if (location.Room.Region != region.ExportName) { continue; }
+        anyConditionalExits |= printThisLoc(writer, location);
+      }
       }
 
-      if (exportedThings)
+      if (anyConditionalExits)
       {
-        // add a blank line if we need one
+        writer.WriteLine("book conditional exit warning");
+        writer.WriteLine();
+        writer.WriteLine("To block conditional exits:");
+        writer.WriteLine("\tsay \"An export nymph appears on your keyboard. She says, 'You can't go that way, as that exit was marked as conditional, you know, a dotted line, in Trizbort. Obviously in your game you'll have a better rationale for this than, er, me.' She looks embarrassed. 'Bye!'\"");
         writer.WriteLine();
       }
+
     }
 
     private string getArticle(string noun)

--- a/Room.cs
+++ b/Room.cs
@@ -1297,7 +1297,7 @@ namespace Trizbort
                 float abSlope = Math.Abs(slope);
                 bool isNeg = (slope > 0);
                 bool isLeft = (xDelta > 0);
-                switch (Settings.AdjustGranularity)
+                switch (Settings.PortAdjustDetail)
                 {  //These numbers are decided as follows: tangent of 45 degrees, then 22.5/67.5, then 11.25/33.75/56.25/78.75
                     case 0: //fourths
                         if (abSlope > 1) { cp = CompassPoint.North; }

--- a/Room.cs
+++ b/Room.cs
@@ -44,7 +44,14 @@ namespace Trizbort
     private readonly TextBlock mName = new TextBlock();
     private readonly TextBlock mSubTitle = new TextBlock();
     private readonly TextBlock mObjects = new TextBlock();
-    private bool mIsDark;
+    private bool mIsDark = false;
+    private bool mRoundedCorners = false;
+    private bool mOctagonal = false;
+    private bool mEllipse = false;
+    private bool mStraightEdges = false;
+    private bool mAllCornersEqual = true;
+    private bool mIsStartRoom = false;
+    private CornerRadii mCorners;
     private CompassPoint mObjectsPosition = DEFAULT_OBJECTS_POSITION;
     // Added for linking connections when pasting
     private int mOldID;
@@ -268,14 +275,47 @@ namespace Trizbort
     public override Depth Depth => Depth.Medium;
     public override bool HasDialog => true;
 
-    public CornerRadii Corners { get; set; }
+    public CornerRadii Corners
+    {
+      get { return mCorners; }
+      set { if (mCorners != value) { mCorners = value; RaiseChanged(); } }
+    }
 
-    public bool RoundedCorners { get; set; } = false;
-    public bool Octagonal { get; set; } = false;
-    public bool Ellipse { get; set; } = false;
-    public bool StraightEdges { get; set; } = false;
-    public bool AllCornersEqual { get; set; } = true;
-    public bool IsStartRoom { get; set; } = false;
+    public bool RoundedCorners
+    {
+      get { return mRoundedCorners; }
+      set { if (mRoundedCorners != value) { mRoundedCorners = value; RaiseChanged(); } }
+    }
+
+    public bool Octagonal
+    {
+      get { return mOctagonal; }
+      set { if (mOctagonal != value) { mOctagonal = value; RaiseChanged(); } }
+    }
+
+    public bool Ellipse
+    {
+      get { return mEllipse; }
+      set { if (mEllipse != value) { mEllipse = value; RaiseChanged(); } }
+    }
+
+    public bool StraightEdges
+    {
+      get { return mStraightEdges; }
+      set { if (mStraightEdges != value) { mStraightEdges = value; RaiseChanged(); } }
+    }
+
+    public bool AllCornersEqual
+    {
+      get { return mAllCornersEqual; }
+      set { if (mAllCornersEqual != value) { mAllCornersEqual = value; RaiseChanged(); } }
+    }
+
+    public bool IsStartRoom
+    {
+      get { return mIsStartRoom; }
+      set { if (mIsStartRoom != value) { mIsStartRoom = value; RaiseChanged(); } }
+    }
 
     public bool IsConnected
     {

--- a/Room.cs
+++ b/Room.cs
@@ -1065,6 +1065,7 @@ namespace Trizbort
         dialog.Ellipse = Ellipse;
         dialog.StraightEdges = StraightEdges;
         dialog.AllCornersEqual = AllCornersEqual;
+        dialog.Shape = Shape;
 
         if (dialog.ShowDialog() == DialogResult.OK)
         {
@@ -1095,6 +1096,7 @@ namespace Trizbort
           Region = dialog.RoomRegion;
           Corners = dialog.Corners;
           RoundedCorners = dialog.RoundedCorners;
+          Shape = dialog.Shape;
           //Octagonal = dialog.Octagonal;
           Ellipse = dialog.Ellipse;
           StraightEdges = dialog.StraightEdges;

--- a/RoomPropertiesDialog.cs
+++ b/RoomPropertiesDialog.cs
@@ -112,6 +112,12 @@ namespace Trizbort
       }
     }
 
+    public RoomShape Shape
+    {
+      get { return (RoomShape)cboDrawType.SelectedIndex; }
+      set { cboDrawType.SelectedItem = (int)value; }
+    }
+
     public string RoomName
     {
       get { return txtName.Text.Trim(); }

--- a/Settings.cs
+++ b/Settings.cs
@@ -417,7 +417,7 @@ namespace Trizbort
     public static int GenVerticalMargin { get; set; }
     public static int CanvasWidth { get; set; }
     public static int CanvasHeight { get; set; }
-    public static int AdjustGranularity { get; set; }
+    public static int PortAdjustDetail { get; set; }
     public static int DefaultImageType { get; set; }
     public static bool InvertMouseWheel { get; set; }
     public static Version DontCareAboutVersion { get; set; }
@@ -480,7 +480,7 @@ namespace Trizbort
             LastExportTadsFileName = root["lastExportedTadsFileName"].Text;
 
             InvertMouseWheel = root["invertMouseWheel"].ToBool(InvertMouseWheel);
-            AdjustGranularity = root["adjustGranularity"].ToInt(AdjustGranularity);
+            PortAdjustDetail = root["portAdjustDetail"].ToInt(PortAdjustDetail);
             DefaultImageType = root["defaultImageType"].ToInt(DefaultImageType);
             SaveToImage = root["saveToImage"].ToBool(SaveToImage);
             SaveToPDF = root["saveToPDF"].ToBool(SaveToPDF);
@@ -535,7 +535,7 @@ namespace Trizbort
           scribe.Element("showMiniMap", ShowMiniMap);
           scribe.Element("invertMouseWheel", InvertMouseWheel);
           scribe.Element("defaultImageType", DefaultImageType);
-          scribe.Element("adjustGranularity", AdjustGranularity);
+          scribe.Element("portAdjustDetail", PortAdjustDetail);
           scribe.Element("saveAt100", SaveAt100);
           scribe.Element("saveToPDF", SaveToPDF);
           scribe.Element("saveToImage", SaveToImage);
@@ -1056,7 +1056,7 @@ namespace Trizbort
       {
         dialog.InvertMouseWheel = InvertMouseWheel;
         dialog.DefaultImageType = DefaultImageType;
-        dialog.AdjustGranularity = AdjustGranularity;
+        dialog.PortAdjustDetail = PortAdjustDetail;
         dialog.SaveToImage = SaveToImage;
         dialog.SaveToPDF = SaveToPDF;
         dialog.SaveTADSToADV3Lite = SaveTADSToADV3Lite;
@@ -1070,7 +1070,7 @@ namespace Trizbort
         {
           InvertMouseWheel = dialog.InvertMouseWheel;
           DefaultImageType = dialog.DefaultImageType;
-          AdjustGranularity = dialog.AdjustGranularity;
+          PortAdjustDetail = dialog.PortAdjustDetail;
           SaveAt100 = dialog.SaveAt100;
           SaveToImage = dialog.SaveToImage;
           SaveToPDF = dialog.SaveToPDF;


### PR DESCRIPTION
I also made a change to the "about" code. We needed to throw in a [line break], and with the code being arranged by books, etc., we needed to throw in a WriteLine, which I think made the code look a bit nicer anyway.

I want to make it so there is 1 line of space between suitably different lines of code e.g.

part TilesIslet

There is a room called TilesIslet. The printed name of it is "Tiles/Islet". It is in Resort.

A Rock is in TilesIslet.
A Swing is in TilesIslet.

East of TilesIslet is An Odd Low Woodland. West of An Odd Low Woodland is nowhere.

Instead of going east from TilesIslet, block conditional exits.

This was tested with my trizbort files for Shuffling Around (26 rooms) and Roiling Original (84). It compiled in the IDE.