### PR TITLE
#212 change default font and allow option

### DIFF
--- a/AppSettingsDialog.Designer.cs
+++ b/AppSettingsDialog.Designer.cs
@@ -33,6 +33,8 @@
       this.m_invertWheelCheckBox = new System.Windows.Forms.CheckBox();
       this.labelG = new System.Windows.Forms.Label();
       this.cboPortAdjustDetail = new System.Windows.Forms.ComboBox();
+      this.txtDefaultFontName = new System.Windows.Forms.TextBox();
+      this.labelFont = new System.Windows.Forms.Label();
       this.cboImageSaveType = new System.Windows.Forms.ComboBox();
       this.label2 = new System.Windows.Forms.Label();
       this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
@@ -88,9 +90,11 @@
       this.groupBox1.Controls.Add(this.chkLoadLast);
       this.groupBox1.Controls.Add(this.cboPortAdjustDetail);
       this.groupBox1.Controls.Add(this.labelG);
+      this.groupBox1.Controls.Add(this.txtDefaultFontName);
+      this.groupBox1.Controls.Add(this.labelFont);
       this.groupBox1.Location = new System.Drawing.Point(6, 16);
       this.groupBox1.Name = "groupBox1";
-      this.groupBox1.Size = new System.Drawing.Size(400, 80);
+      this.groupBox1.Size = new System.Drawing.Size(400, 88);
       this.groupBox1.TabIndex = 3;
       this.groupBox1.TabStop = false;
       this.groupBox1.Text = "Preferences";
@@ -150,6 +154,27 @@
       this.labelG.TabIndex = 2;
       this.labelG.Text = "Port Ad&just Detail:";
       // 
+      // txtDefaultFontName
+      // 
+      this.txtDefaultFontName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+      this.txtDefaultFontName.BackColor = System.Drawing.SystemColors.Window;
+      this.txtDefaultFontName.CausesValidation = false;
+      this.txtDefaultFontName.Location = new System.Drawing.Point(300, 64);
+      this.txtDefaultFontName.Name = "txtDefaultFontName";
+      this.txtDefaultFontName.Size = new System.Drawing.Size(75, 21);
+      this.txtDefaultFontName.TabIndex = 5;
+      // 
+      // labelFont
+      // 
+      this.labelFont.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+      this.labelFont.AutoSize = true;
+      this.labelFont.Location = new System.Drawing.Point(200, 66);
+      this.labelFont.Name = "labelFont";
+      this.labelFont.Size = new System.Drawing.Size(97, 13);
+      this.labelFont.TabIndex = 4;
+      this.labelFont.Text = "Default &Font Name";
+      // 
       // cboImageSaveType
       // 
       this.cboImageSaveType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -187,9 +212,9 @@
       this.groupBox2.Controls.Add(this.label2);
       this.groupBox2.Controls.Add(this.labelH);
       this.groupBox2.Controls.Add(this.labelV);
-      this.groupBox2.Location = new System.Drawing.Point(6, 102);
+      this.groupBox2.Location = new System.Drawing.Point(6, 106);
       this.groupBox2.Name = "groupBox2";
-      this.groupBox2.Size = new System.Drawing.Size(400, 120);
+      this.groupBox2.Size = new System.Drawing.Size(400, 116);
       this.groupBox2.TabIndex = 12;
       this.groupBox2.TabStop = false;
       this.groupBox2.Text = "Smart Save";
@@ -427,6 +452,8 @@
         private System.Windows.Forms.Label labelG;
         private System.Windows.Forms.ComboBox cboImageSaveType;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox txtDefaultFontName;
+        private System.Windows.Forms.Label labelFont;
         private System.Windows.Forms.CheckBox chkSaveAtZoom;
         private System.Windows.Forms.CheckBox chkLoadLast;
         private System.Windows.Forms.ToolTip toolTip2;

--- a/AppSettingsDialog.cs
+++ b/AppSettingsDialog.cs
@@ -70,6 +70,12 @@ namespace Trizbort
       set { cboImageSaveType.SelectedIndex = value; }
     }
 
+    public string DefaultFontName
+    {
+      get { return txtDefaultFontName.Text; }
+      set { txtDefaultFontName.Text = value; }
+    }
+
     public int PortAdjustDetail
     {
       get { return cboPortAdjustDetail.SelectedIndex; }

--- a/Settings.cs
+++ b/Settings.cs
@@ -73,9 +73,9 @@ namespace Trizbort
         new Region {RegionName = Region.DefaultRegion, RColor = System.Drawing.Color.White}
       };
       RecentProjects = new MruList();
-      Reset();
       ResetApplicationSettings();
       LoadApplicationSettings();
+      Reset();
     }
 
     private static string ApplicationSettingsPath
@@ -419,6 +419,7 @@ namespace Trizbort
     public static int CanvasHeight { get; set; }
     public static int PortAdjustDetail { get; set; }
     public static int DefaultImageType { get; set; }
+    public static string DefaultFontName { get; set; }
     public static bool InvertMouseWheel { get; set; }
     public static Version DontCareAboutVersion { get; set; }
 
@@ -481,6 +482,7 @@ namespace Trizbort
 
             InvertMouseWheel = root["invertMouseWheel"].ToBool(InvertMouseWheel);
             PortAdjustDetail = root["portAdjustDetail"].ToInt(PortAdjustDetail);
+            DefaultFontName = root["defaultFontName"].Text;
             DefaultImageType = root["defaultImageType"].ToInt(DefaultImageType);
             SaveToImage = root["saveToImage"].ToBool(SaveToImage);
             SaveToPDF = root["saveToPDF"].ToBool(SaveToPDF);
@@ -534,6 +536,7 @@ namespace Trizbort
           scribe.Element("infiniteScrollBounds", InfiniteScrollBounds);
           scribe.Element("showMiniMap", ShowMiniMap);
           scribe.Element("invertMouseWheel", InvertMouseWheel);
+          scribe.Element("defaultFontName", DefaultFontName);
           scribe.Element("defaultImageType", DefaultImageType);
           scribe.Element("portAdjustDetail", PortAdjustDetail);
           scribe.Element("saveAt100", SaveAt100);
@@ -766,9 +769,9 @@ namespace Trizbort
       Color[Colors.Grid] = Drawing.Mix(System.Drawing.Color.White, System.Drawing.Color.Black, 25, 1);
       Color[Colors.StartRoom] = System.Drawing.Color.GreenYellow;
 
-      LargeFont = new Font("Comic Sans MS", 13.0f, FontStyle.Regular, GraphicsUnit.World);
-      SmallFont = new Font("Comic Sans MS", 11.0f, FontStyle.Regular, GraphicsUnit.World);
-      LineFont = new Font("Comic Sans MS", 9.0f, FontStyle.Regular, GraphicsUnit.World);
+      LargeFont = new Font(DefaultFontName, 13.0f, FontStyle.Regular, GraphicsUnit.World);
+      SmallFont = new Font(DefaultFontName, 11.0f, FontStyle.Regular, GraphicsUnit.World);
+      LineFont = new Font(DefaultFontName, 9.0f, FontStyle.Regular, GraphicsUnit.World);
 
       LineWidth = 2.0f;
       HandDrawn = true;
@@ -1055,6 +1058,7 @@ namespace Trizbort
       using (var dialog = new AppSettingsDialog())
       {
         dialog.InvertMouseWheel = InvertMouseWheel;
+        dialog.DefaultFontName = DefaultFontName;
         dialog.DefaultImageType = DefaultImageType;
         dialog.PortAdjustDetail = PortAdjustDetail;
         dialog.SaveToImage = SaveToImage;
@@ -1069,6 +1073,7 @@ namespace Trizbort
         if (dialog.ShowDialog() == DialogResult.OK)
         {
           InvertMouseWheel = dialog.InvertMouseWheel;
+          DefaultFontName = dialog.DefaultFontName;
           DefaultImageType = dialog.DefaultImageType;
           PortAdjustDetail = dialog.PortAdjustDetail;
           SaveAt100 = dialog.SaveAt100;


### PR DESCRIPTION
There's some tricky stuff in here. Shifting Reset() was not done lightly. Since that code is hit more often, I want to detail it first.

I also think it's named too vaguely. Maybe ResetProjectToApp() is more accurate? (This is obviously low priority, but I got tripped up.)

ResetApplicationSettings();
LoadApplicationSettings();
Reset();

At any rate, if it is before, then the first project you open gets Microsoft Sans Serif font with the new code. Before, it would go to Comic Sans. Otherwise, it works well. Reset changes nothing else that ResetApp... and LoadApp... change.

In fact I think this will help fix the behavior I saw with specifying margins by default in new apps.

So Reset() looks like it should be first because it is a more general name, but if/as we move to having more default app values, there are more reasons to put Reset() should be last.

Re: the code for changing fonts itself, I made sure that changing the default font didn't upset files I already created.

The dialog box for app settings is getting crowded. Hopefully it's not too bad. I can't manipulate the GUI since I have only Visual Community 2015.

But maybe it's about time to break off a separate tab? I keep saying, this is the last option we can fit in...