### PR TITLE
#230 fix plus remove wrong cursor over checkbox

### DIFF
--- a/SettingsDialog.Designer.cs
+++ b/SettingsDialog.Designer.cs
@@ -1117,13 +1117,13 @@ namespace Trizbort
       // m_documentSpecificMargins
       // 
       this.m_documentSpecificMargins.AutoSize = true;
-      this.m_documentSpecificMargins.Cursor = System.Windows.Forms.Cursors.Help;
       this.m_documentSpecificMargins.Location = new System.Drawing.Point(112,9);
       this.m_documentSpecificMargins.Name = "m_documentSpecificMargins";
       this.m_documentSpecificMargins.Size = new System.Drawing.Size(200, 17);
       this.m_documentSpecificMargins.TabIndex = 0;
       this.m_documentSpecificMargins.Text = "Document-Specific Margins";
       this.m_documentSpecificMargins.UseVisualStyleBackColor = true;
+      this.m_documentSpecificMargins.CheckedChanged += new System.EventHandler(this.m_documentSpecificMargins_CheckedChanged);
       // 
       // m_documentHorizontalMargins
       // 

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -71,6 +71,8 @@ namespace Trizbort
       m_RegionListing.DrawMode = DrawMode.OwnerDrawFixed;
       m_RegionListing.DrawItem += RegionListBox_DrawItem;
       m_RegionListing.SelectedIndex = 0;
+
+      m_documentVerticalMargins.Enabled = m_documentHorizontalMargins.Enabled = m_documentSpecificMargins.Checked;
     }
 
     public string Title { get { return m_titleTextBox.Text; } set { m_titleTextBox.Text = value; } }
@@ -471,6 +473,10 @@ namespace Trizbort
       }
     }
 
+    private void m_documentSpecificMargins_CheckedChanged(object sender, EventArgs e)
+    {
+      m_documentHorizontalMargins.Enabled = m_documentVerticalMargins.Enabled = m_documentSpecificMargins.Checked;
+    }
 
     private void tabControl1_Selected(object sender, TabControlEventArgs e)
     {


### PR DESCRIPTION
In some code I cut and pasted earlier from something with a tooltip, I deleted the tooltip but didn't delete the cursor. So I threw that change in too.

Code change is in 2 places in SettingsDialog.cs since we need to check for if we should grey out the margin fields initially.