### PR TITLE
#234 i6 special character name export

### DIFF
--- a/Export/CodeExporter.cs
+++ b/Export/CodeExporter.cs
@@ -623,6 +623,30 @@ namespace Trizbort.Export
       }
     }
 
+    public static string deaccent (string mystr)
+    {
+      string x = "";
+      foreach (var c in mystr)
+      {
+        if ((c >= 'à') && (c <= 'å')) x = x + 'a';
+        else if ((c >= 'À') && (c <= 'Å')) x = x + 'A';
+        else if (c == 'Ç') x = x + 'C';
+        else if (c == 'ç') x = x + 'c';
+        else if ((c >= 'è') && (c <= 'ë')) x = x + 'e';
+        else if ((c >= 'È') && (c <= 'Ë')) x = x + 'E';
+        else if ((c >= 'ì') && (c <= 'ï')) x = x + 'i';
+        else if ((c >= 'Ì') && (c <= 'Ï')) x = x + 'I';
+        else if (c == 'ñ') x = x + 'n';
+        else if (c == 'Ñ') x = x + 'N';
+        else if ((c >= 'Ò') && (c <= 'Ö')) x = x + 'o';
+        else if ((c >= 'ò') && (c <= 'ö')) x = x + 'O';
+        else if ((c >= 'ù') && (c <= 'ü')) x = x + 'u';
+        else if ((c >= 'Ù') && (c <= 'Ü')) x = x + 'U';
+        else x = x + c;
+      }
+      return x;
+    }
+
     protected class Thing
     {
       public Thing(string displayName, string exportName, Location location, Thing container, int indent)

--- a/Export/Inform6Exporter.cs
+++ b/Export/Inform6Exporter.cs
@@ -130,8 +130,8 @@ namespace Trizbort.Export
           continue;
         }
 
-        writer.WriteLine("Object {0} {1} {2}", repeat("-> ", indent), thing.ExportName, toI6String(stripOddCharacters(thing.DisplayName, ' ', '-').Trim(), DOUBLE_QUOTE));
-        writer.Write("  with  name {0}", toI6Words(stripOddCharacters(thing.DisplayName, ' ', '-')));
+        writer.WriteLine("Object {0} {1} {2}", repeat("-> ", indent), thing.ExportName, toI6String(stripUnaccentedCharacters(thing.DisplayName).Trim(), DOUBLE_QUOTE));
+        writer.Write("  with  name {0}", toI6Words(deaccent(stripUnaccentedCharacters(thing.DisplayName))));
         if (thing.Contents.Count > 0)
         {
           writer.WriteLine(",");
@@ -161,7 +161,7 @@ namespace Trizbort.Export
         {
           output += ' ';
         }
-        output += toI6String(word, SINGLE_QUOTE);
+        output += toI6String(deaccent(word), SINGLE_QUOTE);
       }
       return output;
     }
@@ -221,7 +221,7 @@ namespace Trizbort.Export
 
     protected override string GetExportName(Room room, int? suffix)
     {
-      var name = stripOddCharacters(room.Name);
+      var name = deaccent(stripUnaccentedCharacters(room.Name)).Replace(" ", "");
       if (string.IsNullOrEmpty(name))
       {
         name = "room";
@@ -235,7 +235,7 @@ namespace Trizbort.Export
 
     protected override string GetExportName(string displayName, int? suffix)
     {
-      var name = stripOddCharacters(displayName);
+      var name = deaccent(stripUnaccentedCharacters(displayName)).Replace(" ", "");
       if (string.IsNullOrEmpty(name))
       {
         name = "item";
@@ -245,6 +245,11 @@ namespace Trizbort.Export
         name = $"{name}{suffix}";
       }
       return name;
+    }
+
+    private static string stripUnaccentedCharacters(string text)
+    {
+      return stripOddCharacters(text, 'À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ù', 'Ú', 'Û', 'Ü', 'ß', 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', 'ù', 'ú', 'û', 'ü', ' ', '-');
     }
 
     private static string stripOddCharacters(string text, params char[] exclude)


### PR DESCRIPTION
deaccent seems like a good general function if we want to fix things for other languages (and I think we do) so I put it in CodeExporter.cs. Basically, generateur without the accents is acceptable and preferred for the parser. So we want to account for that.

stripunaccentedcharacters is less aggressive than the original stripoddcharacters, as it would be nice to allow for as many foreign languages as possible.

I tested this with diesel.trizbort which is here: https://gist.github.com/andrewschultz/e3b7577b8eb26fa436d8

The exported file now matches Hugo's suggestions.

As I sent in this pull request I realized there's still a question of what to do with the ß character for German. So I may be adding a small push to that e.g.

if (c == 'ß') x = x + "ss"