### PR TITLE
#246 initialize author/title/etc to empty string

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -768,6 +768,8 @@ namespace Trizbort
       Color[Colors.Grid] = Drawing.Mix(System.Drawing.Color.White, System.Drawing.Color.Black, 25, 1);
       Color[Colors.StartRoom] = System.Drawing.Color.GreenYellow;
 
+      Project.Current.Title = Project.Current.Author = Project.Current.History = Project.Current.Description = "";
+
       LargeFont = new Font(DefaultFontName, 13.0f, FontStyle.Regular, GraphicsUnit.World);
       SmallFont = new Font(DefaultFontName, 11.0f, FontStyle.Regular, GraphicsUnit.World);
       LineFont = new Font(DefaultFontName, 9.0f, FontStyle.Regular, GraphicsUnit.World);


### PR DESCRIPTION
For some reason project.current.author gets assigned by default to null but dialog.author does not.

The solution is just to assign the metadata to "" and thus when trizbort compares, it's the empty string vs the empty string instead of null vs the empty string.

I checked where these strings were used. They are used in export and we always check for isNullOrWhiteSpace (and we should, in case the user mistakenly leaves a space in there.)

For testing i checked saving documents with various fields blank. They looked the same before and after the change.