### PR TITLE
#251 last zil filename now exported

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -717,10 +717,10 @@ namespace Trizbort
 
     private void zILToolStripMenuItem_Click(object sender, EventArgs e)
     {
-      var fileName = Settings.LastExportTadsFileName;
+      var fileName = Settings.LastExportZILFileName;
       if (ExportCode<ZilExporter>(ref fileName))
       {
-        Settings.LastExportTadsFileName = fileName;
+        Settings.LastExportZILFileName = fileName;
       }
     }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -438,6 +438,7 @@ namespace Trizbort
     public static string LastExportInform6FileName { get; set; }
     public static string LastExportTadsFileName { get; set; }
     public static string LastExportHugoFileName { get; set; }
+    public static string LastExportZILFileName { get; set; }
     public static MruList RecentProjects { get; private set; }
 
     private static void ResetApplicationSettings()
@@ -479,6 +480,8 @@ namespace Trizbort
             LastExportInform7FileName = root["lastExportedInform7FileName"].Text;
             LastExportInform6FileName = root["lastExportedInform6FileName"].Text;
             LastExportTadsFileName = root["lastExportedTadsFileName"].Text;
+            LastExportHugoFileName = root["lastExportedHugoFileName"].Text;
+            LastExportZILFileName = root["lastExportedZilFileName"].Text;
 
             InvertMouseWheel = root["invertMouseWheel"].ToBool(InvertMouseWheel);
             PortAdjustDetail = root["portAdjustDetail"].ToInt(PortAdjustDetail);
@@ -562,6 +565,7 @@ namespace Trizbort
           scribe.Element("lastExportedInform6FileName", LastExportInform6FileName);
           scribe.Element("lastExportedTadsFileName", LastExportTadsFileName);
           scribe.Element("lastExportedHugoFileName", LastExportHugoFileName);
+          scribe.Element("lastExportedZilFileName", LastExportZILFileName);
 
           scribe.StartElement("recentProjects");
           var index = 0;


### PR DESCRIPTION
This should be pretty straightforward. Code was cut/pasted and changed from TADS to Zil, but the programmer missed a case.

I tacked on a LastExportHugoFileName to the XML as it looks like I forgot to put that in there when I originally wrote the Hugo exporter module.