### PR TITLE
Fix when false errors show up in I7 export

### DIFF
--- a/Export/CodeExporter.cs
+++ b/Export/CodeExporter.cs
@@ -286,7 +286,7 @@ namespace Trizbort.Export
           // the display name is simply the object name without indentation and without and trailing []
           var displayName = objectName.Trim();
 
-          var propString = "";
+          string propString = "";
 
           Regex rgx = new Regex(@"\[[^\]\[]*\]");
 
@@ -294,6 +294,7 @@ namespace Trizbort.Export
 
           if (match.Success)
           {
+            propString = displayName;
             displayName = rgx.Replace(displayName, "");
             Regex rgx2 = new Regex(@".*\[");
             propString = rgx2.Replace(propString, "");

--- a/Export/CodeExporter.cs
+++ b/Export/CodeExporter.cs
@@ -286,15 +286,20 @@ namespace Trizbort.Export
           // the display name is simply the object name without indentation and without and trailing []
           var displayName = objectName.Trim();
 
-          var propString = displayName;
+          var propString = "";
 
           Regex rgx = new Regex(@"\[[^\]\[]*\]");
-          displayName = rgx.Replace(displayName, "");
 
-          Regex rgx2 = new Regex(@".*\[");
-          propString = rgx2.Replace(propString, "");
-          rgx2 = new Regex(@"\].*");
-          propString = rgx2.Replace(propString, "");
+          Match match = rgx.Match(displayName);
+
+          if (match.Success)
+          {
+            displayName = rgx.Replace(displayName, "");
+            Regex rgx2 = new Regex(@".*\[");
+            propString = rgx2.Replace(propString, "");
+            rgx2 = new Regex(@"\].*");
+            propString = rgx2.Replace(propString, "");
+          }
 
           if (string.IsNullOrEmpty(displayName))
           {


### PR DESCRIPTION
With the new bracketed text to determine person/scenery etc., I needed to account for, er, if someone didn't use brackets at all. Now I did.