### PR TITLE
fix extra spacing in n/ne/nw item lists

### DIFF
--- a/Room.cs
+++ b/Room.cs
@@ -1016,8 +1016,7 @@ namespace Trizbort
         {
           if (!Settings.DebugDisableTextRendering)
           {
-            var aObjects = mObjects.Text.Split('\n');
-            var tString = aObjects.Take(MAX_OBJECTS).Aggregate(string.Empty, (current, aObject) => current + (aObject + "\n"));
+            var tString = mObjects.Text;
             var displayObjects = new TextBlock() {Text = tString};
 
             var block = displayObjects.Draw(graphics, font, brush, pos, Vector.Zero, format);


### PR DESCRIPTION
This code just seems like a fancy way of tacking on an extra carriage return we don't need. But I'm wondering if Genstein was trying to do something I wasn't aware of.

I think it looks neater without the carriage return, and it would be most flexible to allow the user to define custom offsets from the 8 basic positions, if they want.

I don't like the idea of forcing an extra carriage return as Genstein's code does, because the user can put one in if they want, if they need the spacing.