### PR TITLE
end room now appears in stats

### DIFF
--- a/MapStatistics.cs
+++ b/MapStatistics.cs
@@ -12,9 +12,16 @@ namespace Trizbort
 
     public static int NumberOfStartRooms => Project.Current.Elements.OfType<Room>().Count(p => p.IsStartRoom);
 
+    public static int NumberOfEndRooms => Project.Current.Elements.OfType<Room>().Count(p => p.IsEndRoom);
+
     public static string StartRoomName
     {
       get { foreach (var x in Project.Current.Elements.OfType<Room>()) { if (x.IsStartRoom) { return x.Name; } } return "(None)"; }
+    }
+
+    public static string EndRoomName
+    {
+      get { foreach (var x in Project.Current.Elements.OfType<Room>()) { if (x.IsEndRoom) { return x.Name; } } return "(None)"; }
     }
 
     public static int NumberOfFloatingRooms

--- a/UI/MapStatisticsView.cs
+++ b/UI/MapStatisticsView.cs
@@ -31,6 +31,14 @@ namespace Trizbort.UI
         stats += $"No start room.";
       stats += $"{Environment.NewLine}";
 
+      if (MapStatistics.NumberOfEndRooms == 1)
+        stats += $"End room = {MapStatistics.EndRoomName}";
+      else if (MapStatistics.NumberOfEndRooms == 2)
+        stats += $"More than one end room.";
+      else
+        stats += $"No end room.";
+      stats += $"{Environment.NewLine}";
+
       stats += $"{Environment.NewLine}";
       stats += $"# of Connections: {MapStatistics.NumberOfConnections}{Environment.NewLine}";
       stats += $"# of Dangling Connections: {MapStatistics.NumberOfDanglingConnections}{Environment.NewLine}";


### PR DESCRIPTION
What the summary says. I don't think there's much that could regress here, but we wrote the stat routine before adding the end room. Tested on trizbort maps with and without end rooms.