### PR TITLE
initial room zoom is now accurate to nearest percent

### DIFF
--- a/UI/Controls/Canvas.cs
+++ b/UI/Controls/Canvas.cs
@@ -2664,13 +2664,17 @@ namespace Trizbort.UI.Controls
     {
       ResetZoomOrigin();
       var canvasBounds = ComputeCanvasBounds(false);
-      while (!Viewport.Contains(canvasBounds))
+      if (!Viewport.Contains(canvasBounds))
       {
-        ZoomOut();
+        float xRatio = (float)(canvasBounds.Left - canvasBounds.Right) / (float)(Left - Right);
+        float yRatio = (float)(canvasBounds.Top - canvasBounds.Bottom) / (float)(Top - Bottom);
+
+        ZoomFactor = Math.Min(xRatio, yRatio);
 
         // Added an escape clause in the case the map is too large to shrink to the screen
         if (ZoomFactor <= 1/10.00f)
         {
+          ZoomFactor = 1/10.00f;
           return;
         }
       }


### PR DESCRIPTION
Genstein's code basically just ran several zooms (5/4 factor) til it worked. This appears to be more accurate.

If we want, we can tack on (document-specific) margins to the (left-right)and (top-bottom) calculations. But I think this is a lot cleaner.

I just noticed I probably threw too many (float)'s in there. Is there any utility or option in Visual C# that is a good code format checker? It'd be neat to be able to do this, like PyCharm does for Python.