### PR TITLE
door and connection changes

### DIFF
--- a/MapStatistics.cs
+++ b/MapStatistics.cs
@@ -14,6 +14,18 @@ namespace Trizbort
 
     public static int NumberOfEndRooms => Project.Current.Elements.OfType<Room>().Count(p => p.IsEndRoom);
 
+    public static int NumberOfOneWayConnections => Project.Current.Elements.OfType<Connection>().Count(p => p.Flow == ConnectionFlow.OneWay);
+
+    public static int NumberOfDottedConnections => Project.Current.Elements.OfType<Connection>().Count(p => p.Style == ConnectionStyle.Dashed);
+
+    public static int NumberOfDoors => Project.Current.Elements.OfType<Door>().Count();
+
+    public static int NumberOfLockedDoors => Project.Current.Elements.OfType<Door>().Count(p => p.Locked);
+
+    public static int NumberOfOpenDoors => Project.Current.Elements.OfType<Door>().Count(p => p.Open);
+
+    public static int NumberOfOpenableDoors => Project.Current.Elements.OfType<Door>().Count(p => p.Openable);
+
     public static string StartRoomName
     {
       get { foreach (var x in Project.Current.Elements.OfType<Room>()) { if (x.IsStartRoom) { return x.Name; } } return "(None)"; }
@@ -106,6 +118,37 @@ namespace Trizbort
             }
             return true;
         });
+      }
+    }
+
+    public static int UpDown
+    {
+        get {
+        return Project.Current.Elements.OfType<Connection>().Count(p =>
+        {
+          if ((p.EndText == $"up") && (p.StartText == $"down"))
+            return true;
+          if ((p.EndText == $"down") && (p.StartText == $"up"))
+            return true;
+          return false;
+        }
+        );
+      }
+    }
+
+    public static int InOut
+    {
+      get
+      {
+        return Project.Current.Elements.OfType<Connection>().Count(p =>
+        {
+          if ((p.EndText == $"in") && (p.StartText == $"out"))
+            return true;
+          if ((p.EndText == $"out") && (p.StartText == $"in"))
+            return true;
+          return false;
+        }
+        );
       }
     }
 

--- a/UI/MapStatisticsView.cs
+++ b/UI/MapStatisticsView.cs
@@ -40,11 +40,18 @@ namespace Trizbort.UI
       stats += $"{Environment.NewLine}";
 
       stats += $"{Environment.NewLine}";
-      stats += $"# of Connections: {MapStatistics.NumberOfConnections}{Environment.NewLine}";
+      stats += $"# of Connections: {MapStatistics.NumberOfConnections}, {MapStatistics.NumberOfOneWayConnections} one-way, {MapStatistics.NumberOfDottedConnections} dashed/dotted," +
+        $"{MapStatistics.UpDown} up/down, {MapStatistics.InOut} in/out.{Environment.NewLine}";
       stats += $"# of Dangling Connections: {MapStatistics.NumberOfDanglingConnections}{Environment.NewLine}";
       stats += $"# of Self Looping Connections: {MapStatistics.NumberOfLoopingConnections}{Environment.NewLine}";
 
       stats += $"# of Dead Ends: {MapStatistics.NumberOfDeadEnds}{Environment.NewLine}";
+
+      stats += $"{Environment.NewLine}";
+      stats += string.Format("{0} door{1}, {2} locked, {3} open, {4} openable{5}",
+        MapStatistics.NumberOfDoors, plur(MapStatistics.NumberOfDoors),
+        MapStatistics.NumberOfLockedDoors, MapStatistics.NumberOfOpenDoors, MapStatistics.NumberOfOpenableDoors,
+        Environment.NewLine);
 
       stats += $"{Environment.NewLine}";
       stats += $"# of Regions: {MapStatistics.NumberOfRegions}{Environment.NewLine}";
@@ -65,6 +72,11 @@ namespace Trizbort.UI
       stats += $"Total # Rooms with Objects: {MapStatistics.NumberOfRoomsWithObjects}{Environment.NewLine}";
 
       return stats;
+    }
+
+    public string plur (int x)
+    {
+      return (x == 1 ? "" : "s");
     }
 
     public void MapStatisticsView_Export(object sender, EventArgs e)


### PR DESCRIPTION
added door/connection stats. None of the really esoteric stats I talked about in #342.

The plur function simply tacks on an s if an integer isn't 1, to make a number plural e.g. 0 door(s). It might be useful other places if more stats are added.

I just did some odd stuff with push I'd never done before, so I hope nothing odd happens with this pull, but if it does, let me know.