### PR TITLE
check for null ports in diagonal/bent (correct source this time)

### DIFF
--- a/MapStatistics.cs
+++ b/MapStatistics.cs
@@ -206,8 +206,9 @@ namespace Trizbort
         var port1 = (Room.CompassPort)p.VertexList[0].Port;
         var port2 = (Room.CompassPort)p.VertexList[1].Port;
 
-        var firstRoomConnectionDir = (int)port1?.CompassPoint;
-        var secondRoomConnectionDir = (int)port2?.CompassPoint;
+        var firstRoomConnectionDir = (port1 == null) ? 0 : (int)port1?.CompassPoint;
+        var secondRoomConnectionDir = (port2 == null) ? 0 : (int)port2?.CompassPoint;
+
         var diags = 0;
 
         if ((firstRoomConnectionDir % 4 == 2) && (p.VertexList[0].Connection.StartText == ""))
@@ -226,6 +227,9 @@ namespace Trizbort
         {
         var port1 = (Room.CompassPort)p.VertexList[0].Port;
         var port2 = (Room.CompassPort)p.VertexList[1].Port;
+
+        if (port1 == null || port2 == null)
+          return false;
 
         var firstRoomConnectionDir = port1.CompassPoint;
         var secondRoomConnectionDir = port2.CompassPoint;


### PR DESCRIPTION
Sorry about the aborted pull request. I forgot to save the file before committing/pushing & so one line was in the wrong place.

This fixes the crashes but doesn't fix the issue with the "bent connections" name. If you think of a good name, let me know.

Values default to 0 (north) for null ports in the diagonalConnections function, which means we return a 0 in the diagonal count.

Either port being null means a connection can't be bent since there is no room to go to.