### PR TITLE
use strict/warnings added to PERL test files

### DIFF
--- a/testing/font-all.pl
+++ b/testing/font-all.pl
@@ -15,6 +15,26 @@
 
 use POSIX;
 
+use strict;
+use warnings;
+
+########################
+#options
+#
+
+my $justPrintFonts = 0;
+my $lowBound = 0;
+my $upperBound = 0;
+my $noFormatting = 0;
+my $toQuit = 0;
+my $quitAt = 0;
+
+########################
+#variables
+#
+
+my $fontCount = 0;
+
 preProcessCmd();
 
 $|=1;
@@ -45,7 +65,7 @@ else { print "No key.\n"; }
 
 RegCloseKey( $key );
 
-for $curfont (sort keys %allfonts)
+for my $curfont (sort keys %allfonts)
 {
   # font name is nicer looking/more descriptive than font file name, so use that
 
@@ -66,8 +86,8 @@ for $curfont (sort keys %allfonts)
   if ($quitAt) { $toQuit++; if ($toQuit > $quitAt) { print "You've run your $quitAt tests. Finished!\n"; last; } }
 
   # ok, go through with processing it.
-
   my $outStr = "fonttest-$data.trizbort";
+  my $params="";
   open(A, "unavailable-font.trizbort");
   open(B, ">$outStr");
   while ($a = <A>)
@@ -107,10 +127,11 @@ if ($quitAt)
 
 sub preProcessCmd
 {
+  my $count = 0;
   while ($count <= $#ARGV)
   {
-    $a = @ARGV[$count];
-    $b = @ARGV[$count+1];
+    $a = $ARGV[$count];
+    $b = $ARGV[$count+1];
     for ($a)
     {
       /^-q$/ && do { $quitAt = $b; $toQuit = 0; $count+= 2; next; };
@@ -123,7 +144,7 @@ sub preProcessCmd
       usage();
     }
   }
-  if ($lowbound && $upperBound && (lc($lowBound) ge lc($upperBound)))
+  if ($lowBound && $upperBound && (lc($lowBound) ge lc($upperBound)))
   {
     die("You specified a lower bound greater than an upper bound. Bailing.");
   }

--- a/testing/testsync.pl
+++ b/testing/testsync.pl
@@ -4,6 +4,21 @@
 #also checks if a trizbort file is used in more than one test case
 
 use Win32::Clipboard;
+use strict;
+use warnings;
+
+#########################
+#options
+my $runZipAfter = 0;
+my $sendToClip = 0;
+
+#########################
+#variables
+my %trizfile;
+my $orphanedFiles = 0;
+my $badFiles = 0;
+my $clip;
+my $clipString = "";
 
 processCmdLine();
 
@@ -13,7 +28,7 @@ my @triz = readdir(DIR);
 
 close(DIR);
 
-for $batfile (@triz)
+for my $batfile (@triz)
 {
   if ($batfile =~ /\.bat/i)
   {
@@ -21,7 +36,7 @@ for $batfile (@triz)
   }
 }
 
-for $thistriz (@triz)
+for my $thistriz (@triz)
 {
   if ($thistriz =~ /\.trizbort/i)
   {
@@ -71,8 +86,11 @@ else
 
 sub getTriz
 {
+  my %warning;
+  my $skip = 0;
   print "Reading $_[0]\n";
   open(A, "$_[0]");
+
   while ($a = <A>)
   {
     if ($a =~ /^::/) { next; }


### PR DESCRIPTION
I found a small bug with variable name capitalization in the process. My experiences on stackoverflow have convinced me it's a good idea to use these for any script over 10 lines.