### PR TITLE
fix (rooms) - room shapes were calculated incorrectly - Fixes #394

### DIFF
--- a/Room.cs
+++ b/Room.cs
@@ -1740,11 +1740,11 @@ public class CornerRadii
 
 public enum RoomShape
 {
-  NotARoom,
   SquareCorners,
   RoundedCorners,
   Ellipse,
-  Octagonal
+  Octagonal,
+  NotARoom
 }
 
 public enum PropertiesStartType


### PR DESCRIPTION
causes exception when opening room dialog and rooms shapes could be changed without meaning too.