### PR TITLE
fix (settings): fix recently opened files list in menu

### DIFF
--- a/Domain/AppSettings/ApplicationSettings.cs
+++ b/Domain/AppSettings/ApplicationSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Trizbort.Automap;
 using Trizbort.Domain.Application;
 
@@ -38,7 +39,7 @@ namespace Trizbort.Domain.AppSettings
     public bool LoadLastProjectOnStart { get; set; }
     public int MouseDragButton { get; set; }
     public int PortAdjustDetail { get; set; }
-    public MruList RecentProjects { get; } = new MruList();
+    public List<string> RecentProjects { get; } = new List<string>();
     public bool SaveAt100 { get; set; }
     public bool SaveTadstoAdv3Lite { get; set; }
     public bool SaveToImage { get; set; }

--- a/Domain/AppSettings/ApplicationSettingsController.cs
+++ b/Domain/AppSettings/ApplicationSettingsController.cs
@@ -153,7 +153,7 @@ namespace Trizbort.Domain.AppSettings {
                 fileName = recentProjects[$"fileName{index++}"].Text;
                 if (!string.IsNullOrEmpty(fileName))
                 {
-                  settings.RecentProjects.Append(fileName);
+                  settings.RecentProjects.Add(fileName);
                 }
               } while (!string.IsNullOrEmpty(fileName));
 
@@ -175,5 +175,23 @@ namespace Trizbort.Domain.AppSettings {
         }
       }
 
+    public static void OpenProject(string fileName) {
+      AppSettings.LastProjectFileName = fileName;
+      if (!AppSettings.RecentProjects.Contains(fileName))
+      {
+        AppSettings.RecentProjects.Insert(0, fileName);
+      }
+      else
+      {
+        AppSettings.RecentProjects.Remove(fileName);
+        AppSettings.RecentProjects.Insert(0, fileName);
+      }
+
+      if (AppSettings.RecentProjects.Count > 4)
+      {
+        AppSettings.RecentProjects.RemoveRange(4, AppSettings.RecentProjects.Count - 4);
+      }
+      SaveSettings();
+    }
   }
 }

--- a/Domain/Controllers/CopyController.cs
+++ b/Domain/Controllers/CopyController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -70,16 +71,18 @@ namespace Trizbort.Domain.Controllers
 
     public ICopyObj PasteElements()
     {
-      var clipboardText = Clipboard.GetText();
-
       ICopyObj xx;
-      if (clipboardText.Contains("\"CopyType\": 1"))
-      {
-        xx = JsonConvert.DeserializeObject<CopyColorsObj>(clipboardText);
+      try {
+        var clipboardText = Clipboard.GetText();
+
+        if (clipboardText.Contains("\"CopyType\": 1")) {
+          xx = JsonConvert.DeserializeObject<CopyColorsObj>(clipboardText);
+        } else {
+          xx = JsonConvert.DeserializeObject<CopyObject>(clipboardText);
+        }
       }
-      else
-      {
-        xx = JsonConvert.DeserializeObject<CopyObject>(clipboardText);
+      catch  {
+        xx = null;
       }
 
       return xx;

--- a/Trizbort.csproj
+++ b/Trizbort.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Domain\Misc\MoveablePort.cs" />
     <Compile Include="Domain\Application\MruList.cs" />
     <Compile Include="Domain\Misc\Numeric.cs" />
+    <Compile Include="Util\ClipboardHelper.cs" />
     <Compile Include="Util\PathHelper.cs" />
     <Compile Include="Domain\Misc\Port.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/UI/Controls/Canvas.cs
+++ b/UI/Controls/Canvas.cs
@@ -2908,18 +2908,19 @@ namespace Trizbort.UI.Controls
       var controller = new CopyController();
       var objs = controller.PasteElements();
 
-      if (objs.GetType() == typeof(CopyController.CopyObject))
-      {
-        var xx = objs as CopyController.CopyObject;
-        pasteRooms(atCursor, xx, controller);
+      if (objs != null) {
+        if (objs.GetType() == typeof(CopyController.CopyObject))
+        {
+          var xx = objs as CopyController.CopyObject;
+          pasteRooms(atCursor, xx, controller);
 
+        }
+        else if (objs.GetType() == typeof(CopyController.CopyColorsObj))
+        {
+          var xx = objs as CopyController.CopyColorsObj;
+          pasteColors(xx);
+        }
       }
-      else if (objs.GetType() == typeof(CopyController.CopyColorsObj))
-      {
-        var xx = objs as CopyController.CopyColorsObj;
-        pasteColors(xx);
-      }
-
     }
 
     private void pasteColors(CopyController.CopyColorsObj xx)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -99,8 +99,9 @@ namespace Trizbort.UI {
       var project = new Project {FileName = fileName};
       if (project.Load()) {
         Project.Current = project;
-        ApplicationSettingsController.AppSettings.LastProjectFileName = fileName;
-        ApplicationSettingsController.AppSettings.RecentProjects.Add(fileName);
+
+        ApplicationSettingsController.OpenProject(fileName);
+
         return true;
       }
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1070,7 +1070,7 @@ namespace Trizbort.UI {
       m_editSelectAllMenuItem.Enabled = Canvas.SelectedElementCount < Project.Current.Elements.Count;
       m_editCopyMenuItem.Enabled = Canvas.SelectedElement != null;
       m_editCopyColorToolMenuItem.Enabled = Canvas.HasSingleSelectedElement && Canvas.SelectedElement is Room;
-      m_editPasteMenuItem.Enabled = !string.IsNullOrEmpty(Clipboard.GetText()) && (Clipboard.GetText().Replace("\r\n", "|").Split('|')[0] == "Elements" || Clipboard.GetText().Replace("\r\n", "|").Split('|')[0] == "Colors");
+      m_editPasteMenuItem.Enabled = ClipboardHelper.HasSomethingToPaste();
       if (Canvas.HasSingleSelectedElement) //Allow flipping light in all rooms if 1+ are selected. Issue #138 flicker
         m_editIsDarkMenuItem.Enabled = Canvas.HasSingleSelectedElement && Canvas.SelectedElement is Room;
       else

--- a/Util/ClipboardHelper.cs
+++ b/Util/ClipboardHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace Trizbort.Util {
+  public static class ClipboardHelper {
+    public static bool HasSomethingToPaste() {
+      if (string.IsNullOrEmpty(Clipboard.GetText()))
+        return false;
+
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
The recently open maps list was not working since we moved the settings
to a JSON format.  Made it so this worked again and opened it up to
add some configuration for this section in the future.