### PR TITLE
Solution for #459

### DIFF
--- a/Domain/AppSettings/ApplicationSettings.cs
+++ b/Domain/AppSettings/ApplicationSettings.cs
@@ -47,6 +47,7 @@ namespace Trizbort.Domain.AppSettings
     public bool ShowMiniMap { get; set; }
     public bool ShowToolTipsOnObjects { get; set; } = true;
     public bool SpecifyGenMargins { get; set; }
+    public bool SpecifyWrapping { get; set; }
     public bool ShowFullPathInTitleBar { get; set; }
   }
 }

--- a/Domain/Elements/Room.cs
+++ b/Domain/Elements/Room.cs
@@ -1200,6 +1200,12 @@ namespace Trizbort.Domain.Elements {
       // no match
     }
 
+    public void MarkNameInvalid() {
+      // it might be a better idea to make that change via public method
+      System.Reflection.FieldInfo fi = mName.GetType().GetField("m_invalidLayout", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+      fi.SetValue(mName, true);
+    }
+
     public Port PortAt(CompassPoint compassPoint) {
       return PortList.Cast<CompassPort>().FirstOrDefault(port => port.CompassPoint == compassPoint);
     }

--- a/Domain/Misc/TextBlock.cs
+++ b/Domain/Misc/TextBlock.cs
@@ -147,14 +147,15 @@ namespace Trizbort.Domain.Misc {
           wordsStep1.Add(new Word(word, (float) graphics.MeasureString(word, font).Width));
         }
 
+        bool isSplitDash = Setup.Settings.WrapTextAtDashes;
         var words = new List<Word>();
-        foreach (var splits in wordsStep1.Where(p => !string.IsNullOrWhiteSpace(p.Text)).Select(word => word.Text.Split('-')))
+        foreach (var splits in wordsStep1.Where(p => !string.IsNullOrWhiteSpace(p.Text)).Select(word => isSplitDash ? word.Text.Split('-') : new string[] { word.Text }))
           if (splits.Count() > 1) {
             var tWordList = new List<Word>();
             foreach (var tWord in splits) {
               if (words.Count != 0 && tWordList.Count == 0)
                 tWordList.Add(new Word(" ", spaceLength));
-              else if (tWordList.Count != 0)
+              else if (tWordList.Count != 0 && isSplitDash)
                 tWordList.Add(new Word("-", hyphenLength));
 
               tWordList.Add(new Word(tWord, (float) graphics.MeasureString(tWord, font).Width));

--- a/Setup/Settings.cs
+++ b/Setup/Settings.cs
@@ -66,6 +66,8 @@ namespace Trizbort.Setup {
     private static bool sDocSpecificMargins;
     private static float sDocHorizontalMargin;
     private static float sDocVerticalMargin;
+    private static bool sWrapTextAtDashes;
+    private static bool sWrappingChanged;
     private static float sDragDistanceToInitiateNewConnection;
     private static float sConnectionArrowSize;
     private static Keys sKeypadNavigationCreationModifier;
@@ -147,6 +149,23 @@ namespace Trizbort.Setup {
         }
       }
     }
+
+    public static bool WrapTextAtDashes {
+      get => sWrapTextAtDashes;
+      set {
+        if (sWrapTextAtDashes == value) return;
+        sWrapTextAtDashes = value;
+        sWrappingChanged = true;
+        raiseChanged();
+      }
+    }
+
+    public static bool WrappingChanged {
+      get => sWrappingChanged;
+      set {
+        sWrappingChanged = value;
+      }//
+    }//
 
     public static float DragDistanceToInitiateNewConnection {
       get => sDragDistanceToInitiateNewConnection;
@@ -400,6 +419,7 @@ namespace Trizbort.Setup {
       DocumentSpecificMargins = element["margins"]["documentSpecific"].ToBool(sDocSpecificMargins);
       DocHorizontalMargin = element["margins"]["horizontal"].ToFloat(sDocHorizontalMargin);
       DocVerticalMargin = element["margins"]["vertical"].ToFloat(sDocVerticalMargin);
+      WrapTextAtDashes = element["margins"]["wrapDashes"].ToBool(true); // maybe should be somewhere else
 
       KeypadNavigationCreationModifier = stringToModifierKeys(element["keypadNavigation"]["creationModifier"].Text, sKeypadNavigationCreationModifier);
       KeypadNavigationUnexploredModifier = stringToModifierKeys(element["keypadNavigation"]["unexploredModifier"].Text, sKeypadNavigationUnexploredModifier);
@@ -437,6 +457,8 @@ namespace Trizbort.Setup {
       } else {
         DocHorizontalMargin = DocVerticalMargin = 0;
       }
+
+      WrapTextAtDashes = ApplicationSettingsController.AppSettings.SpecifyWrapping;
 
       LineWidth = 2.0f;
 
@@ -527,6 +549,7 @@ namespace Trizbort.Setup {
       scribe.Element("documentSpecific", sDocSpecificMargins);
       scribe.Element("horizontal", sDocHorizontalMargin);
       scribe.Element("vertical", sDocVerticalMargin);
+      scribe.Element("wrapDashes", sWrapTextAtDashes); // maybe should be somewhere else
       scribe.EndElement();
 
       scribe.StartElement("keypadNavigation");
@@ -573,6 +596,7 @@ namespace Trizbort.Setup {
         dialog.DocumentSpecificMargins = DocumentSpecificMargins;
         dialog.DocHorizontalMargin = DocHorizontalMargin;
         dialog.DocVerticalMargin = DocVerticalMargin;
+        dialog.WrapTextAtDashes = WrapTextAtDashes;
         dialog.ConnectionArrowSize = ConnectionArrowSize;
         dialog.DefaultRoomShape = DefaultRoomShape;
         if (dialog.ShowDialog() == DialogResult.OK) {
@@ -631,6 +655,8 @@ namespace Trizbort.Setup {
           DocHorizontalMargin = dialog.DocHorizontalMargin;
           if (DocVerticalMargin != dialog.DocVerticalMargin) Project.Current.IsDirty = true;
           DocVerticalMargin = dialog.DocVerticalMargin;
+          if (WrapTextAtDashes != dialog.WrapTextAtDashes) Project.Current.IsDirty = true;
+          WrapTextAtDashes = dialog.WrapTextAtDashes;
           if (DefaultRoomShape != dialog.DefaultRoomShape) Project.Current.IsDirty = true;
           DefaultRoomShape = dialog.DefaultRoomShape;
         }

--- a/UI/Controls/Canvas.cs
+++ b/UI/Controls/Canvas.cs
@@ -1744,13 +1744,16 @@ namespace Trizbort.UI.Controls {
       delta = Drawing.Divide(delta, ZoomFactor);
       Origin = new Vector(Origin.X + delta.X, Origin.Y + delta.Y);
       mPanPosition = clientPos;
-      // if tooltip is already shown, move it with the element
-      // the below code causes tooltip to flicker when panning
-      if (trizbortToolTip1.IsShown && trizbortToolTip1.HoverElement is Element element) {
-        var newPoint = GetTooltipPositionFromElement(element);
-        if (trizbortToolTip1.IsPositionChanged(newPoint)) // not really necessary as panning always changes the position
-          trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
+      if (trizbortToolTip1.IsShown) {
+        trizbortToolTip1.Hide(trizbortToolTip1.LastOwner);
       }
+      //// if tooltip is already shown, move it with the element
+      //// the below code causes tooltip to flicker when panning
+      //if (trizbortToolTip1.IsShown && trizbortToolTip1.HoverElement is Element element) {
+      //  var newPoint = GetTooltipPositionFromElement(element);
+      //  if (trizbortToolTip1.IsPositionChanged(newPoint)) // not really necessary as panning always changes the position
+      //    trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
+      //}
     }
 
     private void drawElements(XGraphics graphics, Palette palette, bool finalRender) {
@@ -2198,13 +2201,16 @@ namespace Trizbort.UI.Controls {
       // move any selected moveable elements
       if (element is IMoveable moveable) {
         moveable.Position += delta;
-        // if tooltip is already shown, move it with the element
-        // the below code causes tooltip to flicker when moving the element and grid snapping is off
-        if (trizbortToolTip1.IsShown && element == trizbortToolTip1.HoverElement) {
-          var newPoint = GetTooltipPositionFromElement(element);
-          if (trizbortToolTip1.IsPositionChanged(newPoint))
-            trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
+        if (trizbortToolTip1.IsShown) {
+          trizbortToolTip1.Hide(trizbortToolTip1.LastOwner);
         }
+        //// if tooltip is already shown, move it with the element
+        //// the below code causes tooltip to flicker when moving the element and grid snapping is off
+        //if (trizbortToolTip1.IsShown && element == trizbortToolTip1.HoverElement) {
+        //  var newPoint = GetTooltipPositionFromElement(element);
+        //  if (trizbortToolTip1.IsPositionChanged(newPoint))
+        //    trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
+        //}
       }
 
       if (element is Connection) {

--- a/UI/Controls/Canvas.cs
+++ b/UI/Controls/Canvas.cs
@@ -1751,7 +1751,7 @@ namespace Trizbort.UI.Controls {
         if (trizbortToolTip1.IsPositionChanged(newPoint)) // not really necessary as panning always changes the position
           trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
       }
-     }
+    }
 
     private void drawElements(XGraphics graphics, Palette palette, bool finalRender) {
       if (ApplicationSettingsController.AppSettings.DebugDisableElementRendering)

--- a/UI/Controls/Canvas.cs
+++ b/UI/Controls/Canvas.cs
@@ -1744,7 +1744,14 @@ namespace Trizbort.UI.Controls {
       delta = Drawing.Divide(delta, ZoomFactor);
       Origin = new Vector(Origin.X + delta.X, Origin.Y + delta.Y);
       mPanPosition = clientPos;
-    }
+      // if tooltip is already shown, move it with the element
+      // the below code causes tooltip to flicker when panning
+      if (trizbortToolTip1.IsShown && trizbortToolTip1.HoverElement is Element element) {
+        var newPoint = GetTooltipPositionFromElement(element);
+        if (trizbortToolTip1.IsPositionChanged(newPoint)) // not really necessary as panning always changes the position
+          trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
+      }
+     }
 
     private void drawElements(XGraphics graphics, Palette palette, bool finalRender) {
       if (ApplicationSettingsController.AppSettings.DebugDisableElementRendering)
@@ -2188,10 +2195,16 @@ namespace Trizbort.UI.Controls {
     }
 
     private void moveElementBy(Element element, Vector delta) {
-      if (element is IMoveable) {
-        // move any selected moveable elements
-        var moveable = (IMoveable) element;
+      // move any selected moveable elements
+      if (element is IMoveable moveable) {
         moveable.Position += delta;
+        // if tooltip is already shown, move it with the element
+        // the below code causes tooltip to flicker when moving the element and grid snapping is off
+        if (trizbortToolTip1.IsShown && element == trizbortToolTip1.HoverElement) {
+          var newPoint = GetTooltipPositionFromElement(element);
+          if (trizbortToolTip1.IsPositionChanged(newPoint))
+            trizbortToolTip1.Show(trizbortToolTip1.TitleText, trizbortToolTip1.LastOwner, newPoint);
+        }
       }
 
       if (element is Connection) {
@@ -2706,26 +2719,21 @@ namespace Trizbort.UI.Controls {
             trizbortToolTip1.FooterText = hoverElement.GetToolTipFooter();
             trizbortToolTip1.TitleText = hoverElement.GetToolTipHeader();
 
-            var tPoint = new Vector();
-            if (hoverElement is Room) {
+            if (hoverElement is Room tRoom) {
               trizbortToolTip1.BackColor = Color.LightBlue;
-              var tRoom = (Room) hoverElement;
-              tPoint = tRoom.Position;
               // tPoint.Y += tRoom.Height + 10;
               // tPoint.X -= 10;
-            } else if (hoverElement is Connection) {
+            } else if (hoverElement is Connection tConnection) {
               trizbortToolTip1.BackColor = Color.LemonChiffon;
-              var tConnection = (Connection) hoverElement;
               tConnection.MidText = "";
-              tPoint = tConnection.VertexList[0].Position;
               // tPoint.Y -= 10;
               // tPoint.X -= 10;
             }
 
-            var xxttPoint = CanvasToClient(tPoint);
-            var newPoint = PointToScreen(new Point((int) xxttPoint.X, (int) xxttPoint.Y));
+            var newPoint = GetTooltipPositionFromElement(hoverElement);
 
             this.trizbortToolTip1.Show(trizbortToolTip1.TitleText, FromHandle(Handle), newPoint);
+            this.trizbortToolTip1.HoverElement = hoverElement;
           }
 
           break;
@@ -2745,6 +2753,19 @@ namespace Trizbort.UI.Controls {
           break;
       }
     }
+
+    private Point GetTooltipPositionFromElement(Element element) {
+      var tPoint = new Vector();
+      if (element is Room tRoom) {
+        tPoint = tRoom.Position;
+      }
+      else if (element is Connection tConnection) {
+        tPoint = tConnection.VertexList[0].Position;
+      }
+
+      var xxttPoint = CanvasToClient(tPoint);
+      return PointToScreen(new Point((int)xxttPoint.X, (int)xxttPoint.Y));
+    } //
 
     private void updateSelection() {
       recreateHandles();

--- a/UI/Controls/TrizbortToolTip.cs
+++ b/UI/Controls/TrizbortToolTip.cs
@@ -9,6 +9,10 @@ namespace Trizbort.UI.Controls {
     public string TitleText { get; set; }
     public string BodyText { get; set; }
     public string FooterText { get; set; }
+    public bool IsShown { get; set; }
+    public IWin32Window LastOwner { get; set; }
+    public Point LastPosition { get; private set; }
+    public object HoverElement { get; set; }
 
     public Color GradientColor { get; set; } = Color.Empty;
 
@@ -101,6 +105,57 @@ namespace Trizbort.UI.Controls {
       }
 
       b.Dispose();
+    }
+
+    public bool IsPositionChanged(Point position) {
+      return position.X != LastPosition.X || position.Y != LastPosition.Y;
+    }
+
+    public new void Show(string text, IWin32Window window) {
+      LastOwner = window;
+      base.Show(text, window);
+      IsShown = true;
+    }
+
+    public new void Show(string text, IWin32Window window, int duration) {
+      LastOwner = window;
+      base.Show(text, window, duration);
+      IsShown = true;
+    }
+
+    public new void Show(string text, IWin32Window window, Point point) {
+      LastOwner = window;
+      LastPosition = point;
+      base.Show(text, window, point);
+      IsShown = true;
+    }
+
+    public new void Show(string text, IWin32Window window, int x, int y) {
+      LastOwner = window;
+      LastPosition = new Point(x, y);
+      base.Show(text, window, x, y);
+      IsShown = true;
+    }
+
+    public new void Show(string text, IWin32Window window, Point point, int duration) {
+      LastOwner = window;
+      LastPosition = point;
+      base.Show(text, window, point, duration);
+      IsShown = true;
+    }
+
+    public new void Show(string text, IWin32Window window, int x, int y, int duration) {
+      LastOwner = window;
+      LastPosition = new Point(x, y);
+      base.Show(text, window, x, y, duration);
+      IsShown = true;
+    }
+
+    public new void Hide(IWin32Window win) {
+      LastOwner = null;    // not really necessary
+      HoverElement = null; // as above - this one is being set outside of the class
+      base.Hide(win);
+      IsShown = false;
     }
   }
 }

--- a/UI/SettingsDialog.Designer.cs
+++ b/UI/SettingsDialog.Designer.cs
@@ -124,6 +124,7 @@ namespace Trizbort.UI
       this.btnChange = new System.Windows.Forms.Button();
       this.m_RegionListing = new System.Windows.Forms.ListBox();
       this.tabPage3 = new System.Windows.Forms.TabPage();
+      this.m_wrapTextAtDashes = new System.Windows.Forms.CheckBox();
       this.groupBox4 = new System.Windows.Forms.GroupBox();
       this.label4b = new System.Windows.Forms.Label();
       this.label4c = new System.Windows.Forms.Label();
@@ -1076,8 +1077,19 @@ namespace Trizbort.UI
       this.tabPage3.Text = "Other";
       this.tabPage3.UseVisualStyleBackColor = true;
       // 
+      // m_wrapTextAtDashes
+      // 
+      this.m_wrapTextAtDashes.AutoSize = true;
+      this.m_wrapTextAtDashes.Location = new System.Drawing.Point(6, 48);
+      this.m_wrapTextAtDashes.Name = "m_wrapTextAtDashes";
+      this.m_wrapTextAtDashes.Size = new System.Drawing.Size(128, 17);
+      this.m_wrapTextAtDashes.TabIndex = 2;
+      this.m_wrapTextAtDashes.Text = "Wrap Text at Dashes";
+      this.m_wrapTextAtDashes.UseVisualStyleBackColor = true;
+      // 
       // groupBox4
       // 
+      this.groupBox4.Controls.Add(this.m_wrapTextAtDashes);
       this.groupBox4.Controls.Add(this.label4b);
       this.groupBox4.Controls.Add(this.label4c);
       this.groupBox4.Controls.Add(this.m_documentSpecificMargins);
@@ -1391,5 +1403,6 @@ namespace Trizbort.UI
     private System.Windows.Forms.TextBox m_subtitleFontSizeTextBox;
     private System.Windows.Forms.Button m_changeSubtitleFontButton;
     private System.Windows.Forms.TextBox m_subtitleFontNameTextBox;
+        private System.Windows.Forms.CheckBox m_wrapTextAtDashes;
   }
 }

--- a/UI/SettingsDialog.cs
+++ b/UI/SettingsDialog.cs
@@ -96,6 +96,8 @@ namespace Trizbort.UI {
 
     public bool DocumentSpecificMargins { get => m_documentSpecificMargins.Checked; set => m_documentSpecificMargins.Checked = value; }
 
+    public bool WrapTextAtDashes { get => m_wrapTextAtDashes.Checked; set => m_wrapTextAtDashes.Checked = value; }
+
     public float DocVerticalMargin { get => (float) m_documentVerticalMargins.Value; set => m_documentVerticalMargins.Value = (decimal) value; }
 
     public Color[] ElementColors { get; }


### PR DESCRIPTION
This is my solution proposition for #459 

The tooltip is being re-drawn when it is shown upon panning and moving the element. This causes a rather noticeable tooltip flicker, especially when snap-to-grid is turned off or when panning.

Known "issues":
1. flicker
2. when moving the element or panning in a way that the element is not visible on the canvas, the tooltip "stays" near the visible edge