### PR TITLE
Fix issues with handling of "Hand Drawn Edges" setting.

### DIFF
--- a/Domain/Elements/Room.cs
+++ b/Domain/Elements/Room.cs
@@ -1154,7 +1154,7 @@ namespace Trizbort.Domain.Elements {
       else
         Shape = RoomShape.SquareCorners;
 
-      StraightEdges = element.Attribute("handDrawn").ToBool();
+      HandDrawnEdges = element.Attribute("handDrawn").ToBool();
       AllCornersEqual = element.Attribute("allcornersequal").ToBool();
 
       Corners = new CornerRadii();
@@ -1261,7 +1261,7 @@ namespace Trizbort.Domain.Elements {
       if (ReferenceRoom != null)
         scribe.Attribute("referenceRoom", ReferenceRoom.ID);
 
-      scribe.Attribute("handDrawn", StraightEdges);
+      scribe.Attribute("handDrawn", HandDrawnEdges);
       scribe.Attribute("allcornersequal", AllCornersEqual);
       scribe.Attribute("ellipse", Ellipse);
       scribe.Attribute("roundedCorners", RoundedCorners);

--- a/UI/RoomPropertiesDialog.cs
+++ b/UI/RoomPropertiesDialog.cs
@@ -430,6 +430,9 @@ namespace Trizbort.UI {
         groupRoundedCorners.Visible = false;
       }
 
+      // Hand drawn style is currently only implemented for "Straight Edges" line style.
+      chkHandDrawnRoom.Enabled = (cboDrawType.SelectedItem.ToString() == "Straight Edges");
+
       pnlSampleRoomShape.Invalidate();
     }
 


### PR DESCRIPTION
This patch corrects a problem in the serialization/de-serialization of the `Room` state which was causing the `handDrawn` setting to be inverted by the save and load process.

Additionally the "Hand Drawn Edges" option is now disabled when setting the line drawing style to anything other than "Straight Edges" from the room properties dialog to better inform the user where the option is supported.

