### PR TITLE
I7 Export - Region name is reserved word, room not assigned

### DIFF
--- a/Export/Languages/Inform7Exporter.cs
+++ b/Export/Languages/Inform7Exporter.cs
@@ -77,8 +77,8 @@ namespace Trizbort.Export.Languages {
         writer.WriteLine();
         // export each location
         foreach (var location in LocationsInExportOrder) {
-          if (location.Room.Region != region.ExportName) continue;
-          anyConditionalExits |= printThisLoc(writer, location);
+          if ((location.Room.Region == region.Region.RegionName) ||(location.Room.Region == region.ExportName))
+            anyConditionalExits |= printThisLoc(writer, location);
         }
       }
 


### PR DESCRIPTION
If the region is a reserved word, any rooms would be disconnected from that region (which would have a new name assigned during export)